### PR TITLE
Make the max length of the media name controlable via gsettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ There is a file: src/testWin.py that is not used when installing the applet, but
 ## Issues 
 - Works only on horizontal panels
 - Minimal supported panel size is 32px
-- No maximum length of the text
 
 ## Requirements
 - budgie-1.0 
@@ -18,10 +17,16 @@ There is a file: src/testWin.py that is not used when installing the applet, but
 - python3-pil / python3-pillow
 
 ## Build 
-Only for current user (No root privilegies needed)
+### Ubuntu Budgie
 ~~~ shell
-meson setup build --prefix=~/.local --libdir=share
+meson setup build --libdir=/usr/lib
 
-cd build && ninja install
+cd build && sudo ninja install
+~~~
+### Fedora
+~~~ shell
+meson setup build --libdir=/usr/lib64
+
+cd build && sudo ninja install
 ~~~
 

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,17 @@
 project('budgie-media-player-applet')
 
 
-plugins_install_dir = join_paths(get_option('prefix'), get_option('libdir'), 'budgie-desktop', 'plugins', meson.project_name())
+PLUGINS_INSTALL_DIR = join_paths(get_option('libdir'), 'budgie-desktop', 'plugins', meson.project_name())
 
 
 install_data(
     'budgie-media-player-applet.plugin',
-    install_dir: plugins_install_dir
+    install_dir: PLUGINS_INSTALL_DIR
 )
+
+install_data('schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml',
+    install_dir: '/usr/share/glib-2.0/schemas'
+    )
+meson.add_install_script('meson_post_install.py')
 
 subdir('src')

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+schemadir = os.path.join("/", "usr", "share", "glib-2.0", "schemas")
+
+if not os.environ.get("DESTDIR"):
+    print("Compiling gsettings schemas...")
+    subprocess.call(["glib-compile-schemas", schemadir])

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+    <schema path="/com/github/zalesyc/budgie-media-player-applet/"
+            id="com.github.zalesyc.budgie-media-player-applet">
+        <key type="i" name="author-name-max-length">
+            <summary>Maximum length of author's name</summary>
+            <description>The maximum length, in characters, of the playing media author's name.</description>
+	        <default>25</default>
+        </key>
+
+        <key type="i" name="media-title-max-length">
+            <summary>Maximum length of the playing media's title</summary>
+            <description>The maximum length, in characters, of the playing media's title.</description>
+	        <default>40</default>
+        </key>     
+    </schema>
+</schemalist>

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -47,7 +47,9 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.popover_box.set_margin_end(5)
         self.popover.add(self.popover_box)
 
-        self.settings = Gio.Settings.new("com.github.zalesyc.budgie-media-player-applet")
+        self.settings = Gio.Settings.new(
+            "com.github.zalesyc.budgie-media-player-applet"
+        )
         SingleAppPlayer.author_max_len = self.settings.get_int("author-name-max-length")
         SingleAppPlayer.name_max_len = self.settings.get_int("media-title-max-length")
         self.settings.connect("changed", self.settings_changed)
@@ -125,16 +127,14 @@ class BudgieMediaPlayer(Budgie.Applet):
 
             if len(self.players_list) < 2:
                 self.popup_icon.hide()
-    
+
     def settings_changed(self, settings, key):
         if key == "author-name-max-length" or key == "media-title-max-length":
             if key == "author-name-max-length":
                 SingleAppPlayer.author_max_len = self.settings.get_int(key)
             else:
                 SingleAppPlayer.name_max_len = self.settings.get_int(key)
-            
+
             for appPlayer in self.players_list:
                 appPlayer.reset_song_label()
             return
-        
-        

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -47,6 +47,11 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.popover_box.set_margin_end(5)
         self.popover.add(self.popover_box)
 
+        self.settings = Gio.Settings.new("com.github.zalesyc.budgie-media-player-applet")
+        SingleAppPlayer.author_max_len = self.settings.get_int("author-name-max-length")
+        SingleAppPlayer.name_max_len = self.settings.get_int("media-title-max-length")
+        self.settings.connect("changed", self.settings_changed)
+
         self.dbus_namespace_name = "org.mpris.MediaPlayer2"
         self.session_bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
         self.session_bus.signal_subscribe(
@@ -65,7 +70,6 @@ class BudgieMediaPlayer(Budgie.Applet):
             self.players_list.append(SingleAppPlayer(dbus_name))
             if len(self.players_list) < 2:
                 self.box.pack_start(self.players_list[-1], False, False, 0)
-
             else:
                 self.popover_box.add(self.players_list[-1])
 
@@ -121,3 +125,16 @@ class BudgieMediaPlayer(Budgie.Applet):
 
             if len(self.players_list) < 2:
                 self.popup_icon.hide()
+    
+    def settings_changed(self, settings, key):
+        if key == "author-name-max-length" or key == "media-title-max-length":
+            if key == "author-name-max-length":
+                SingleAppPlayer.author_max_len = self.settings.get_int(key)
+            else:
+                SingleAppPlayer.name_max_len = self.settings.get_int(key)
+            
+            for appPlayer in self.players_list:
+                appPlayer.reset_song_label()
+            return
+        
+        

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -36,7 +36,6 @@ class SingleAppPlayer(Gtk.Box):
     def __init__(self, service_name: str):
         self.album_cover_height: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
         
-
         Gtk.Box.__init__(self, spacing=0)
         self.service_name = service_name
 
@@ -59,7 +58,7 @@ class SingleAppPlayer(Gtk.Box):
         self.song_text = Gtk.Label()
         self._set_song_label(
             start_song_metadata.lookup_value("xesam:artist", None),
-            start_song_metadata.lookup_value("xesam:title", None),
+            start_song_metadata.lookup_value("xesam:title", None)
         )
         song_text_event_box = Gtk.EventBox()
         song_text_event_box.add(self.song_text)
@@ -97,6 +96,10 @@ class SingleAppPlayer(Gtk.Box):
         self.pack_end(self.backward_button, False, False, 0)
 
         self.show_all()
+     
+    def reset_song_label(self) -> None:
+        metadata = self.dbus_player.get_player_property("Metadata")
+        self._set_song_label(metadata.lookup_value("xesam:artist", None), metadata.lookup_value("xesam:title", None))
 
     def playing_changed(self, status: GLib.Variant):
         if status.get_string() == "Playing":

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -30,6 +30,9 @@ from mprisWrapper import MprisWrapper
 
 
 class SingleAppPlayer(Gtk.Box):
+    author_max_len = 30
+    name_max_len = 50
+
     def __init__(self, service_name: str):
         self.album_cover_height: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
         
@@ -154,33 +157,28 @@ class SingleAppPlayer(Gtk.Box):
         button.connect("button-press-event", on_pressed)
         return button
 
-    def _set_song_label(self, author, title):
-        if author is None:
-            author = ""
-        else:
-            author = author.unpack()
-            if len(author) == 0:
-                author = ""
-            else:
-                author = author[0]
-
-        if title is None:
-            title = ""
-        else:
+    def _set_song_label(self, author: GLib.Variant, title: GLib.Variant):
+        splitter = " - "
+        if title is not None:
             title = title.unpack()
 
-        if title == "":
-            if author == "":
-                song_text = "Unknown"
+            if author is not None:
+                author = ", ".join(author.unpack())
+            
             else:
-                song_text = f"{author} - Unknown"
+                splitter = ""
+                author = ""
+        
         else:
-            if author == "":
-                song_text = f"{title}"
+            title = "Unknown"
+            if author is not None:
+                author = ", ".join(author.unpack())
+            
             else:
-                song_text = f"{author} - {title}"
+                splitter = ""
+                author = ""
 
-        self.song_text.set_label(song_text)
+        self.song_text.set_label(f"{author}{splitter}{title}")        
 
     def _set_album_cover(self, art_url):
         if art_url is None:

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -31,7 +31,7 @@ from mprisWrapper import MprisWrapper
 
 class SingleAppPlayer(Gtk.Box):
     author_max_len = 30
-    name_max_len = 50
+    name_max_len = 40
 
     def __init__(self, service_name: str):
         self.album_cover_height: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
@@ -178,7 +178,11 @@ class SingleAppPlayer(Gtk.Box):
                 splitter = ""
                 author = ""
 
-        self.song_text.set_label(f"{author}{splitter}{title}")        
+        self.song_text.set_label("{}{}{}".format(
+            (author[:self.author_max_len - 3] + '...') if len(author) > self.author_max_len else author,
+            splitter,
+            (title[:self.name_max_len - 3] + '...') if len(title) > self.name_max_len else title
+        ))
 
     def _set_album_cover(self, art_url):
         if art_url is None:

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -14,10 +14,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from io import BytesIO
 from urllib.parse import urlparse
 import requests
 from PIL import Image
-from io import BytesIO
 
 import gi
 
@@ -35,7 +35,7 @@ class SingleAppPlayer(Gtk.Box):
 
     def __init__(self, service_name: str):
         self.album_cover_height: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
-        
+
         Gtk.Box.__init__(self, spacing=0)
         self.service_name = service_name
 
@@ -58,7 +58,7 @@ class SingleAppPlayer(Gtk.Box):
         self.song_text = Gtk.Label()
         self._set_song_label(
             start_song_metadata.lookup_value("xesam:artist", None),
-            start_song_metadata.lookup_value("xesam:title", None)
+            start_song_metadata.lookup_value("xesam:title", None),
         )
         song_text_event_box = Gtk.EventBox()
         song_text_event_box.add(self.song_text)
@@ -66,26 +66,43 @@ class SingleAppPlayer(Gtk.Box):
 
         # control buttons
         play_pause_icon = Gtk.Image()
-        self.can_play: bool = self.dbus_player.get_player_property("CanPlay").get_boolean()
-        self.can_pause: bool = self.dbus_player.get_player_property("CanPause").get_boolean()
-        if (self.dbus_player.get_player_property("PlaybackStatus").get_string() == "Playing"):
+        self.can_play: bool = self.dbus_player.get_player_property(
+            "CanPlay"
+        ).get_boolean()
+        self.can_pause: bool = self.dbus_player.get_player_property(
+            "CanPause"
+        ).get_boolean()
+        if (
+            self.dbus_player.get_player_property("PlaybackStatus").get_string()
+            == "Playing"
+        ):
             self.play_pause_button = self._init_button(
-                "media-playback-pause-symbolic", self.play_paused_clicked,
-                enabled=(self.can_pause or self.can_play)
+                "media-playback-pause-symbolic",
+                self.play_paused_clicked,
+                enabled=(self.can_pause or self.can_play),
             )
 
         else:
             self.play_pause_button = self._init_button(
-                "media-playback-start-symbolic", self.play_paused_clicked, 
-                enabled=(self.can_pause or self.can_play)
+                "media-playback-start-symbolic",
+                self.play_paused_clicked,
+                enabled=(self.can_pause or self.can_play),
             )
         self.dbus_player.player_connect("CanPlay", self.can_play_changed)
         self.dbus_player.player_connect("CanPause", self.can_pause_changed)
-     
-        self.backward_button = self._init_button("media-skip-backward-symbolic", self.backward_clicked, enabled=self.dbus_player.get_player_property("CanGoPrevious").get_boolean())
+
+        self.backward_button = self._init_button(
+            "media-skip-backward-symbolic",
+            self.backward_clicked,
+            enabled=self.dbus_player.get_player_property("CanGoPrevious").get_boolean(),
+        )
         self.dbus_player.player_connect("CanGoPrevious", self.can_go_previous_changed)
 
-        self.forward_button = self._init_button("media-skip-forward-symbolic", self.forward_clicked, enabled=self.dbus_player.get_player_property("CanGoNext").get_boolean())
+        self.forward_button = self._init_button(
+            "media-skip-forward-symbolic",
+            self.forward_clicked,
+            enabled=self.dbus_player.get_player_property("CanGoNext").get_boolean(),
+        )
         self.dbus_player.player_connect("CanGoNext", self.can_go_next_changed)
 
         # add all widgets
@@ -96,10 +113,13 @@ class SingleAppPlayer(Gtk.Box):
         self.pack_end(self.backward_button, False, False, 0)
 
         self.show_all()
-     
+
     def reset_song_label(self) -> None:
         metadata = self.dbus_player.get_player_property("Metadata")
-        self._set_song_label(metadata.lookup_value("xesam:artist", None), metadata.lookup_value("xesam:title", None))
+        self._set_song_label(
+            metadata.lookup_value("xesam:artist", None),
+            metadata.lookup_value("xesam:title", None),
+        )
 
     def playing_changed(self, status: GLib.Variant):
         if status.get_string() == "Playing":
@@ -107,7 +127,7 @@ class SingleAppPlayer(Gtk.Box):
                 "media-playback-pause-symbolic", Gtk.IconSize.MENU
             )
             self.play_pause_button.set_image(play_pause_icon)
-            
+
         elif status.get_string() == "Paused":
             play_pause_icon = Gtk.Image.new_from_icon_name(
                 "media-playback-start-symbolic", Gtk.IconSize.MENU
@@ -120,23 +140,20 @@ class SingleAppPlayer(Gtk.Box):
             metadata.lookup_value("xesam:title", None),
         )
         self._set_album_cover(metadata.lookup_value("mpris:artUrl", None))
-    
+
     def can_play_changed(self, metadata: GLib.Variant):
-            self.can_play = metadata.get_boolean()
-            self.backward_button.set_sensitive(self.can_play or self.can_pause)
+        self.can_play = metadata.get_boolean()
+        self.backward_button.set_sensitive(self.can_play or self.can_pause)
 
     def can_pause_changed(self, metadata: GLib.Variant):
         self.can_pause = metadata.get_boolean()
         self.backward_button.set_sensitive(self.can_play or self.can_pause)
 
     def can_go_previous_changed(self, metadata: GLib.Variant):
-            self.backward_button.set_sensitive(metadata.get_boolean())
+        self.backward_button.set_sensitive(metadata.get_boolean())
 
-    def can_go_previous_changed(self, metadata: GLib.Variant):
-            self.backward_button.set_sensitive(metadata.get_boolean())
-    
     def can_go_next_changed(self, metadata: GLib.Variant):
-            self.forward_button.set_sensitive(metadata.get_boolean())
+        self.forward_button.set_sensitive(metadata.get_boolean())
 
     def play_paused_clicked(self, *args):
         self.dbus_player.call_player_method("PlayPause")
@@ -149,9 +166,14 @@ class SingleAppPlayer(Gtk.Box):
 
     def song_clicked(self, *args):
         self.dbus_player.call_app_method("Raise")
-      
 
-    def _init_button(self, icon_name: str, on_pressed: callable, icon_size: Gtk.IconSize = Gtk.IconSize.MENU, enabled: bool = True) -> Gtk.Button:
+    def _init_button(
+        self,
+        icon_name: str,
+        on_pressed: callable,
+        icon_size: Gtk.IconSize = Gtk.IconSize.MENU,
+        enabled: bool = True,
+    ) -> Gtk.Button:
         icon = Gtk.Image.new_from_icon_name(icon_name, icon_size)
         button = Gtk.Button()
         button.set_image(icon)
@@ -167,25 +189,31 @@ class SingleAppPlayer(Gtk.Box):
 
             if author is not None:
                 author = ", ".join(author.unpack())
-            
-            else:
-                splitter = ""
-                author = ""
-        
-        else:
-            title = "Unknown"
-            if author is not None:
-                author = ", ".join(author.unpack())
-            
+
             else:
                 splitter = ""
                 author = ""
 
-        self.song_text.set_label("{}{}{}".format(
-            (author[:self.author_max_len - 3] + '...') if len(author) > self.author_max_len else author,
-            splitter,
-            (title[:self.name_max_len - 3] + '...') if len(title) > self.name_max_len else title
-        ))
+        else:
+            title = "Unknown"
+            if author is not None:
+                author = ", ".join(author.unpack())
+
+            else:
+                splitter = ""
+                author = ""
+
+        self.song_text.set_label(
+            "{}{}{}".format(
+                (author[: self.author_max_len - 3] + "...")
+                if len(author) > self.author_max_len
+                else author,
+                splitter,
+                (title[: self.name_max_len - 3] + "...")
+                if len(title) > self.name_max_len
+                else title,
+            )
+        )
 
     def _set_album_cover(self, art_url):
         if art_url is None:

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,5 +3,5 @@ install_data(
     'SingleAppPlayer.py',
     'BudgieMediaPlayer.py',
     'mprisWrapper.py',
-    install_dir: plugins_install_dir
+    install_dir: PLUGINS_INSTALL_DIR
 )


### PR DESCRIPTION
Created gsettings schema for this applet
In the schema I currently store the max length of the author's name and the media's title

The applet loads the settings on startup, and reponds on change
Currently there is no settings page, so the only way to change those settings is via dconf editor or the terminal
