### PR TITLE
Make the applet work on vertical panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Applet for the budgie panel for controlling all of your playing media
 ![screenshot](screenshot.png)
 
 ## Developing
-There is a file: src/testWin.py that is not used when installing the applet, but it is used for debuging, as it creates the applet in a standalone window.
-If you pass -s as a commandline argument it will instead show the settings page
+There is a file: src/testWin.py that is not used when installing the applet, but it is used for debugging, as it creates the applet in a standalone window.
+If you pass -s as a commandline argument it will instead show the settings page.
+If you pass -v it will show the vertical representation of the applet.
 
 ## Issues 
-- Works only on horizontal panels
 - Minimal supported panel size is 32px
 - Settings apply to all instances of the applet instead of settings per applet
 

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -43,7 +43,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.popover_manager = Budgie.PopoverManager()
         self.popover_manager.register_popover(self, self.popover)
 
-        self.popover_box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 10)
+        self.popover_box = Gtk.Box.new(not self.orientation, 10)
         self.popover_box.set_margin_bottom(5)
         self.popover_box.set_margin_top(5)
         self.popover_box.set_margin_start(5)
@@ -150,6 +150,7 @@ class BudgieMediaPlayer(Budgie.Applet):
             self.orientation = Gtk.Orientation.HORIZONTAL
 
         self.box.set_orientation(self.orientation)
+        self.popover_box.set_orientation(not self.orientation)
         for player in self.players_list:
             player.set_orientation(self.orientation)
 

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -33,8 +33,9 @@ class SingleAppPlayer(Gtk.Box):
     author_max_len = 30
     name_max_len = 40
 
-    def __init__(self, service_name: str):
+    def __init__(self, service_name: str, orientation: Gtk.Orientation):
         self.album_cover_height: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
+        self.orientation: Gtk.Orientation = orientation
 
         Gtk.Box.__init__(self, spacing=0)
         self.service_name = service_name
@@ -105,6 +106,8 @@ class SingleAppPlayer(Gtk.Box):
         )
         self.dbus_player.player_connect("CanGoNext", self.can_go_next_changed)
 
+        self.set_orientation(orientation)
+
         # add all widgets
         self.pack_start(album_cover_event_box, False, False, 5)
         self.pack_start(song_text_event_box, True, True, 5)
@@ -113,6 +116,13 @@ class SingleAppPlayer(Gtk.Box):
         self.pack_end(self.backward_button, False, False, 0)
 
         self.show_all()
+
+    def set_orientation(self, orientation: Gtk.Orientation) -> None:
+        self.orientation = orientation
+        self.song_text.set_angle(
+            0 if orientation == Gtk.Orientation.HORIZONTAL else 270
+        )
+        super().set_orientation(orientation)
 
     def reset_song_label(self) -> None:
         metadata = self.dbus_player.get_player_property("Metadata")
@@ -201,8 +211,6 @@ class SingleAppPlayer(Gtk.Box):
 
             else:
                 author = ", ".join(author.unpack())
-
-           
 
         self.song_text.set_label(
             "{}{}{}".format(

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -34,7 +34,7 @@ class SingleAppPlayer(Gtk.Box):
     name_max_len = 40
 
     def __init__(self, service_name: str, orientation: Gtk.Orientation):
-        self.album_cover_height: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
+        self.album_cover_max_size: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2] 
         self.orientation: Gtk.Orientation = orientation
 
         Gtk.Box.__init__(self, spacing=0)
@@ -122,6 +122,9 @@ class SingleAppPlayer(Gtk.Box):
         self.song_text.set_angle(
             0 if orientation == Gtk.Orientation.HORIZONTAL else 270
         )
+        metadataProperty = self.dbus_player.get_player_property("Metadata")
+        if metadataProperty is not None:
+            self._set_album_cover(metadataProperty.lookup_value("mpris:artUrl", None))
         super().set_orientation(orientation)
 
     def reset_song_label(self) -> None:
@@ -231,20 +234,27 @@ class SingleAppPlayer(Gtk.Box):
 
         url = art_url.get_string()
         parsed_url = urlparse(url)
+        
         if parsed_url.scheme == "file":
             try:
-                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-                    parsed_url.path, -1, self.album_cover_height, True
-                )
+                if self.orientation == Gtk.Orientation.HORIZONTAL:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                        parsed_url.path, -1, self.album_cover_max_size, True
+                    )
+                else:
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                        parsed_url.path, self.album_cover_max_size, -1, True
+                    )                    
                 self.album_cover.set_from_pixbuf(pixbuf)
             except gi.repository.GLib.GError:
                 self._set_album_cover_other()
+            return
 
-        elif parsed_url.scheme == "https":
+        if parsed_url.scheme == "https":
             self._set_album_cover_https(url)
+            return
 
-        else:
-            self._set_album_cover_other()
+        self._set_album_cover_other()
 
     def _set_album_cover_other(self):
         desktop_file_name = self.dbus_player.get_app_property("DesktopEntry")
@@ -269,20 +279,29 @@ class SingleAppPlayer(Gtk.Box):
     def _set_album_cover_https(self, url):
         pixbuf = self._stream_image_to_gdkpixbuf(url)
 
-        if pixbuf:
+        if not pixbuf:
+            self._set_album_cover_other()
+            return
+
+        # calculating width/height based on height/width to have the same proportions
+        if self.orientation == Gtk.Orientation.HORIZONTAL:
             self.album_cover.set_from_pixbuf(
-                pixbuf.scale_simple(
-                    int(
-                        (self.album_cover_height / pixbuf.get_height())
-                        * pixbuf.get_width()
-                    ),  # calculating width based on height to have the same proportions
-                    self.album_cover_height,
-                    GdkPixbuf.InterpType.NEAREST,
+                pixbuf.scale_simple(  
+                    int((self.album_cover_max_size / pixbuf.get_height()) * pixbuf.get_width()), 
+                    self.album_cover_max_size,
+                    GdkPixbuf.InterpType.NEAREST
                 )
             )
-        else:
-            self._set_album_cover_other()
-
+            return
+        
+        self.album_cover.set_from_pixbuf(
+            pixbuf.scale_simple(
+                self.album_cover_max_size,
+                int((self.album_cover_max_size / pixbuf.get_width()) * pixbuf.get_height()), 
+                GdkPixbuf.InterpType.NEAREST
+            )
+        )
+    
     def _stream_image_to_gdkpixbuf(self, url):
         try:
             # Send a GET request to the URL

--- a/src/testWin.py
+++ b/src/testWin.py
@@ -20,7 +20,8 @@ import sys
 import gi.repository
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, Gio
+gi.require_version('Budgie', '1.0')
+from gi.repository import Gtk, GLib, Gio, Budgie
 from BudgieMediaPlayer import BudgieMediaPlayer
 from SettingsPage import SettingsPage
 
@@ -35,6 +36,8 @@ class MyWindow(Gtk.Window):
         else:
             super().__init__(title="MediaPlayerTestWin")
             self.mp = BudgieMediaPlayer(0)
+            if len(sys.argv) > 1 and sys.argv[1] == "-v":
+                self.mp.do_panel_position_changed(Budgie.PanelPosition.LEFT)
         self.add(self.mp)
 
 


### PR DESCRIPTION
Make the applet work on vertical panels
--
If the applet is added to a vertical panel it will make everything vertical
- if the album is not square, it will scale so it can fit to the space event if it is wider than taller
- the song/author label will rotate 270 degrees -> make the text vertical
- the controls will be above themself -> in vertical line 
