### PR TITLE
Add more customization options

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -11,6 +11,11 @@
             <summary>Maximum length of the playing media's title</summary>
             <description>The maximum length, in characters, of the playing media's title.</description>
 	        <default>40</default>
-        </key>     
+        </key>
+        <key type="as" name="element-order">
+            <summary>The order of the elements</summary>
+            <description>The order of the elements in the applet.</description>
+            <default>["album_cover", "song_author", "song_separator", "song_name", "backward_button", "play_pause_button", "forward_button"]</default>
+        </key>
     </schema>
 </schemalist>

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -17,5 +17,10 @@
             <description>The order of the elements in the applet.</description>
             <default>["album_cover", "song_author", "song_separator", "song_name", "backward_button", "play_pause_button", "forward_button"]</default>
         </key>
+        <key type="s" name="separator-text">
+            <summary>The text/character used as the separator</summary>
+            <description>The text/character that is used as the separator.</description>
+            <default>"-"</default>
+        </key>
     </schema>
 </schemalist>

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -42,6 +42,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.author_max_len = self.settings.get_int("author-name-max-length")
         self.name_max_len = self.settings.get_int("media-title-max-length")
         self.element_order = self.settings.get_strv("element-order")
+        self.separator_text = self.settings.get_string("separator-text")
 
         self.box = Gtk.Box(spacing=10)
         self.add(self.box)
@@ -85,6 +86,7 @@ class BudgieMediaPlayer(Budgie.Applet):
                     author_max_len=self.author_max_len,
                     name_max_len=self.name_max_len,
                     element_order=self.element_order,
+                    separator_text=self.separator_text,
                 )
             )
             if len(self.players_list) < 2:
@@ -125,6 +127,7 @@ class BudgieMediaPlayer(Budgie.Applet):
                     author_max_len=self.author_max_len,
                     name_max_len=self.name_max_len,
                     element_order=self.element_order,
+                    separator_text=self.separator_text,
                 ),
             )
             if len(self.players_list) < 2:
@@ -169,11 +172,18 @@ class BudgieMediaPlayer(Budgie.Applet):
             for app_player in self.players_list:
                 app_player.name_max_len = self.name_max_len
                 app_player.reset_song_label()
+            return
 
         if key == "element-order":
             self.element_order = self.settings.get_strv(key)
             for app_player in self.players_list:
                 app_player.set_element_order(self.element_order)
+            return
+
+        if key == "separator-text":
+            self.separator_text = self.settings.get_string("separator-text")
+            for app_player in self.players_list:
+                app_player.set_separator_text(self.separator_text)
 
     def do_panel_size_changed(self, panel_size, icon_size, small_icon_size):
         if len(self.players_list) > 0:

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -41,6 +41,7 @@ class BudgieMediaPlayer(Budgie.Applet):
 
         self.author_max_len = self.settings.get_int("author-name-max-length")
         self.name_max_len = self.settings.get_int("media-title-max-length")
+        self.element_order = self.settings.get_strv("element-order")
 
         self.box = Gtk.Box(spacing=10)
         self.add(self.box)
@@ -83,6 +84,7 @@ class BudgieMediaPlayer(Budgie.Applet):
                     orientation=self.orientation,
                     author_max_len=self.author_max_len,
                     name_max_len=self.name_max_len,
+                    element_order=self.element_order,
                 )
             )
             if len(self.players_list) < 2:
@@ -122,6 +124,7 @@ class BudgieMediaPlayer(Budgie.Applet):
                     orientation=self.orientation,
                     author_max_len=self.author_max_len,
                     name_max_len=self.name_max_len,
+                    element_order=self.element_order,
                 ),
             )
             if len(self.players_list) < 2:
@@ -166,6 +169,11 @@ class BudgieMediaPlayer(Budgie.Applet):
             for app_player in self.players_list:
                 app_player.name_max_len = self.name_max_len
                 app_player.reset_song_label()
+
+        if key == "element-order":
+            self.element_order = self.settings.get_strv(key)
+            for app_player in self.players_list:
+                app_player.set_element_order(self.element_order)
 
     def do_panel_size_changed(self, panel_size, icon_size, small_icon_size):
         if len(self.players_list) > 0:

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -34,6 +34,7 @@ class SettingsPage(Gtk.Box):
         self.stack.add_titled(OrderPage(settings), "order_page", "Order")
 
         stack_switcher = Gtk.StackSwitcher()
+        stack_switcher.set_halign(Gtk.Align.CENTER)
         stack_switcher.set_stack(self.stack)
 
         self.pack_start(stack_switcher, False, False, 0)
@@ -138,6 +139,7 @@ class OrderPage(Gtk.Box):
         self.left_box.set_selection_mode(Gtk.SelectionMode.SINGLE)
 
         middle_buttons_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        middle_buttons_box.set_valign(Gtk.Align.CENTER)
 
         self.right_box = Gtk.ListBox()
         self.right_box.set_property("selection-mode", Gtk.SelectionMode.SINGLE)
@@ -179,8 +181,10 @@ class OrderPage(Gtk.Box):
         self.pack_start(left_frame, True, True, 0)
         self.pack_start(middle_buttons_box, False, False, 0)
         self.pack_start(right_frame, True, True, 0)
-
-        self.enabled_elements_order = settings.get_strv("element-order")
+        if settings is None:
+            self.enabled_elements_order = ["song_author", "song_separator", "song_name"]
+        else:
+            self.enabled_elements_order = settings.get_strv("element-order")
         self.widget_to_element_name_dict: {Gtk.ListBoxRow: str} = {}
         for element_name in self.enabled_elements_order:
             if element_name not in self.available_elements:

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -30,8 +30,8 @@ class SettingsPage(Gtk.Box):
         self.stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)
         self.stack.set_transition_duration(100)
 
-        self.stack.add_titled(MainPage(settings), "main_page", "Main")
-        self.stack.add_titled(OrderPage(settings), "order_page", "Order")
+        self.stack.add_titled(MainPage(settings), "main_page", "General")
+        self.stack.add_titled(OrderPage(settings), "order_page", "Element Order")
 
         stack_switcher = Gtk.StackSwitcher()
         stack_switcher.set_halign(Gtk.Align.CENTER)
@@ -296,10 +296,10 @@ class OrderPage(Gtk.Grid):
 
         self.settings.set_strv("element-order", new_element_order)
 
-    def _on_left_box_selected(self, object, list_row):
-        if list_row is not None:
+    def _on_left_box_selected(self, list_box, selected_list_row):
+        if selected_list_row is not None:
             self.right_list_box.unselect_all()
 
-    def _on_right_box_selected(self, object, list_row):
-        if list_row is not None:
+    def _on_right_box_selected(self, list_box, selected_list_row):
+        if selected_list_row is not None:
             self.left_list_box.unselect_all()

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -81,11 +81,28 @@ class MainPage(Gtk.Grid):
             "value_changed", self.author_max_len_spin_box_changed
         )
 
+        separator_text_label = Gtk.Label.new("Separator:")
+        separator_text_label.set_halign(Gtk.Align.START)
+        self.separator_combobox = Gtk.ComboBoxText.new()
+        available_separators = ("-", ":", "·")
+        for separator in available_separators:
+            self.separator_combobox.append(separator, separator)
+
+        if settings is not None:
+            separator_text = settings.get_string("separator-text")
+            if separator_text in available_separators:
+                self.separator_combobox.set_active_id(separator_text)
+
+        self.separator_combobox.connect("changed", self.separator_combobox_changed)
+
         self.attach(self.max_len_title, 0, 0, 2, 1)
         self.attach(self.name_max_len_label, 0, 1, 1, 1)
         self.attach(self.name_max_len_spin_button, 1, 1, 1, 1)
         self.attach(self.author_max_len_label, 0, 2, 1, 1)
         self.attach(self.author_max_len_spin_button, 1, 2, 1, 1)
+        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 3, 2, 1)
+        self.attach(separator_text_label, 0, 4, 1, 1)
+        self.attach(self.separator_combobox, 1, 4, 1, 1)
 
         self.show_all()
 
@@ -94,6 +111,12 @@ class MainPage(Gtk.Grid):
 
     def author_max_len_spin_box_changed(self, widget):
         self.settings.set_int("author-name-max-length", widget.get_value_as_int())
+
+    def separator_combobox_changed(self, combo_box):
+        self.settings.set_string(
+            "separator-text",
+            self.separator_combobox.get_active_text(),
+        )
 
     def settings_changed(self, settings, key):
         if key == "author-name-max-length":

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -28,6 +28,7 @@ class SettingsPage(Gtk.Box):
 
         self.stack = Gtk.Stack()
         self.stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)
+        self.stack.set_halign(Gtk.Align.CENTER)
         self.stack.set_transition_duration(100)
 
         self.stack.add_titled(MainPage(settings), "main_page", "General")

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -150,26 +150,32 @@ class OrderPage(Gtk.Grid):
         self.right_list_box = Gtk.ListBox()
         self.right_list_box.set_property("selection-mode", Gtk.SelectionMode.SINGLE)
 
+        left_frame = Gtk.Frame()
+        left_frame.add(self.left_list_box)
+
+        right_frame = Gtk.Frame()
+        right_frame.add(self.right_list_box)
+
         self.add_button = Gtk.Button.new_from_icon_name(
             "arrow-right", Gtk.IconSize.BUTTON
         )
-        self.add_button.connect("clicked", self._on_add_clicked)
-
         self.remove_button = Gtk.Button.new_from_icon_name(
             "arrow-left", Gtk.IconSize.BUTTON
         )
-        self.remove_button.connect("clicked", self._on_remove_clicked)
-
         self.move_up_button = Gtk.Button.new_from_icon_name(
             "arrow-up", Gtk.IconSize.BUTTON
         )
-        self.move_up_button.connect("clicked", self._on_move_up_clicked)
-
         self.move_down_button = Gtk.Button.new_from_icon_name(
             "arrow-down", Gtk.IconSize.BUTTON
         )
-        self.move_down_button.connect("clicked", self._on_move_down_clicked)
+        self.move_down_button = Gtk.Button.new_from_icon_name(
+            "arrow-down", Gtk.IconSize.BUTTON
+        )
 
+        self.add_button.connect("clicked", self._on_add_clicked)
+        self.remove_button.connect("clicked", self._on_remove_clicked)
+        self.move_up_button.connect("clicked", self._on_move_up_clicked)
+        self.move_down_button.connect("clicked", self._on_move_down_clicked)
         self.left_list_box.connect("row-selected", self._on_left_box_selected)
         self.right_list_box.connect("row-selected", self._on_right_box_selected)
 
@@ -177,12 +183,6 @@ class OrderPage(Gtk.Grid):
         middle_buttons_box.pack_start(self.remove_button, False, False, 0)
         middle_buttons_box.pack_start(self.move_up_button, False, False, 0)
         middle_buttons_box.pack_start(self.move_down_button, False, False, 0)
-
-        left_frame = Gtk.Frame()
-        left_frame.add(self.left_list_box)
-
-        right_frame = Gtk.Frame()
-        right_frame.add(self.right_list_box)
 
         self.attach(left_description, 0, 0, 1, 1)
         self.attach(right_description, 2, 0, 1, 1)
@@ -194,7 +194,9 @@ class OrderPage(Gtk.Grid):
             self.enabled_elements_order = ["song_author", "song_separator", "song_name"]
         else:
             self.enabled_elements_order = settings.get_strv("element-order")
+
         self.widget_to_element_name_dict: {Gtk.ListBoxRow: str} = {}
+
         for element_name in self.enabled_elements_order:
             if element_name not in self.available_elements:
                 print(

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -213,7 +213,7 @@ class SingleAppPlayer(Gtk.Box):
 
     def set_element_order(self, order: [str], remove_previous: bool = True):
         if remove_previous:
-            self.foreach(self.remove(widget))
+            self.foreach(self.remove)
 
         for element_name in order:
             element = self.available_elements.get(element_name)
@@ -303,7 +303,7 @@ class SingleAppPlayer(Gtk.Box):
         else:
             title = title.unpack()
             if author is None or (not ", ".join(author.unpack())):
-                splitter = ""
+                author = ""
 
             else:
                 author = ", ".join(author.unpack())

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -50,11 +50,13 @@ class SingleAppPlayer(Gtk.Box):
         author_max_len: int,
         name_max_len: int,
         element_order: [str],
+        separator_text: str,
     ):
         self.album_cover_size: int = Gtk.IconSize.lookup(Gtk.IconSize.DND)[2]
         self.orientation: Gtk.Orientation = orientation
         self.author_max_len = author_max_len
         self.name_max_len = name_max_len
+        self.separator_text = separator_text
 
         Gtk.Box.__init__(self, spacing=0)
         self.service_name = service_name
@@ -96,7 +98,7 @@ class SingleAppPlayer(Gtk.Box):
         )
 
         # song_separator
-        self.song_separator = Gtk.Label(label="-")
+        self.song_separator = Gtk.Label(label=self.separator_text)
         self.available_elements.update(
             {"song_separator": Element(self.song_separator, 4)}
         )
@@ -223,6 +225,10 @@ class SingleAppPlayer(Gtk.Box):
             self.pack_start(element.widget, False, False, element.spacing)
 
         self.show_all()
+
+    def set_separator_text(self, new_text: str) -> None:
+        self.separator_text = new_text
+        self.song_separator.set_label(self.separator_text)
 
     def playing_changed(self, status: GLib.Variant):
         if status.get_string() == "Playing":

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -213,7 +213,7 @@ class SingleAppPlayer(Gtk.Box):
 
     def set_element_order(self, order: [str], remove_previous: bool = True):
         if remove_previous:
-            self.foreach(lambda widget: self.remove(widget))
+            self.foreach(self.remove(widget))
 
         for element_name in order:
             element = self.available_elements.get(element_name)


### PR DESCRIPTION
### New options:
 - You can now reorder the applet elements 
 - You can also now set the separator to: ':', '-', '·'