### PR TITLE
Make the popup more customizable

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -42,5 +42,10 @@
             <description>Size of the album cover's bigger side in px.</description>
             <default>180</default>
         </key>
+        <key type="u" name="plasma-popover-text-style">
+            <summary>Style of the name and author text in the plasma popover</summary>
+            <description>Style of the name and author text in the plasma popover, ellipsis: 0, scrolling (marquee): 1.</description>
+            <default>1</default>
+        </key>
     </schema>
 </schemalist>

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -57,5 +57,15 @@
             <description>Size of the playing media's author in the plasma popover, in px, -1 is the system default</description>
             <default>-1</default>
         </key>
+        <key type="d" name="plasma-popover-media-name-scrolling-speed">
+            <summary>Speed of the scrolling of the name text in the plasma popover</summary>
+            <description>Speed of the scrolling of the playing media's name in the plasma popover, when style is set to scroll, currently only positive numbers are used</description>
+            <default>1.0</default>
+        </key>
+        <key type="d" name="plasma-popover-media-author-scrolling-speed">
+            <summary>Speed of the scrolling of the author text in the plasma popover</summary>
+            <description>Speed of the scrolling of the playing media's name in the plasma popover, when style is set to scroll, currently only positive numbers are used.</description>
+            <default>1.0</default>
+        </key>
     </schema>
 </schemalist>

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -47,5 +47,15 @@
             <description>Style of the name and author text in the plasma popover, ellipsis: 0, scrolling (marquee): 1.</description>
             <default>1</default>
         </key>
+        <key type="i" name="plasma-popover-media-name-size">
+            <summary>Size of the name text in the plasma popover</summary>
+            <description>Size of the playing media's name in the plasma popover, in px, -1 is the system default</description>
+            <default>-1</default>
+        </key>
+        <key type="i" name="plasma-popover-media-author-size">
+            <summary>Size of the author text in the plasma popover</summary>
+            <description>Size of the playing media's author in the plasma popover, in px, -1 is the system default</description>
+            <default>-1</default>
+        </key>
     </schema>
 </schemalist>

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -49,17 +49,17 @@
         </key>
         <key type="i" name="plasma-popover-media-name-size">
             <summary>Size of the name text in the plasma popover</summary>
-            <description>Size of the playing media's name in the plasma popover, in px, -1 is the system default</description>
+            <description>Size of the playing media's name in the plasma popover, in px, -1 is the system default.</description>
             <default>-1</default>
         </key>
         <key type="i" name="plasma-popover-media-author-size">
             <summary>Size of the author text in the plasma popover</summary>
-            <description>Size of the playing media's author in the plasma popover, in px, -1 is the system default</description>
+            <description>Size of the playing media's author in the plasma popover, in px, -1 is the system default.</description>
             <default>-1</default>
         </key>
         <key type="d" name="plasma-popover-media-name-scrolling-speed">
             <summary>Speed of the scrolling of the name text in the plasma popover</summary>
-            <description>Speed of the scrolling of the playing media's name in the plasma popover, when style is set to scroll, currently only positive numbers are used</description>
+            <description>Speed of the scrolling of the playing media's name in the plasma popover, when style is set to scroll, currently only positive numbers are used.</description>
             <default>1.0</default>
         </key>
         <key type="d" name="plasma-popover-media-author-scrolling-speed">

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -44,7 +44,7 @@
         </key>
         <key type="u" name="plasma-popover-text-style">
             <summary>Style of the name and author text in the plasma popover</summary>
-            <description>Style of the name and author text in the plasma popover, ellipsis: 0, scrolling (marquee): 1.</description>
+            <description>Style of the name and author text in the plasma popover, ellipting: 0, scrolling (marquee): 1.</description>
             <default>1</default>
         </key>
         <key type="i" name="plasma-popover-media-name-size">

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -97,7 +97,6 @@ class BudgieMediaPlayer(Budgie.Applet):
         for dbus_name in dbus_names:
             new_view = PopupPlasmaControlView(
                 service_name=dbus_name,
-                album_cover_size=self.popover_album_cover_size,
                 open_popover_func=self.show_popup,
                 favorite_clicked=self.favorite_player_clicked,
                 settings=self.settings,
@@ -183,7 +182,6 @@ class BudgieMediaPlayer(Budgie.Applet):
         if (changes[0] not in self.players_list) and changes[2]:  # player was added
             new_view = PopupPlasmaControlView(
                 service_name=changes[0],
-                album_cover_size=self.popover_album_cover_size,
                 open_popover_func=self.show_popup,
                 favorite_clicked=self.favorite_player_clicked,
                 settings=self.settings,

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -215,6 +215,7 @@ class EllipsizedLabel(Gtk.Label):
 
         self.set_max_width_chars(1)
         self.set_ellipsize(EllipsizeMode.END)
+        self.set_xalign(0.0)
 
         self._css_provider = Gtk.CssProvider()
         if text_size is None:

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -15,8 +15,8 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-import gi
 from typing import Optional
+import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
@@ -185,14 +185,14 @@ class ScrollingLabel(Gtk.ScrolledWindow):
 
         return True
 
-    def _wait_for_self_allocate_and_resize(self):
+    def _wait_for_self_allocate_and_resize(self) -> None:
         self._resize(
             self._get_label_width(self._label1),
             self.get_allocated_width(),
         )
         self.connect("size-allocate", self._size_allocate)
 
-    def _size_allocate(self, _, rect: Gdk.Rectangle):
+    def _size_allocate(self, _, rect: Gdk.Rectangle) -> None:
         self._resize(
             self._get_label_width(self._label1),
             rect.width,

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -204,9 +204,9 @@ class ScrollingLabel(Gtk.ScrolledWindow):
         return label.get_layout().get_pixel_size()[0]
 
 
-class EllipsizedLabel(Gtk.Label):
+class ElliptedLabel(Gtk.Label):
     """
-    Elipsized label that can set its text size,
+    Ellipted label that can set its text size,
     if text_size is None, a system default will be used
     """
 

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -1,0 +1,257 @@
+#    budgie-media-player-applet
+#    Copyright (C) 2024 Alex Cizinsky
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import gi
+from typing import Optional
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+gi.require_version("Pango", "1.0")
+
+
+from gi.repository import Gtk, Gdk
+from gi.repository.Pango import EllipsizeMode
+
+
+class ScrollingLabel(Gtk.ScrolledWindow):
+    """
+    Label that is scrolling if longer then parent
+
+    if text_size is None, system default will be used
+
+    """
+
+    def __init__(
+        self,
+        text: str = "",
+        speed: float = 1.0,
+        text_size: Optional[int] = None,
+        is_visible: bool = False,
+    ):
+        Gtk.ScrolledWindow.__init__(self)
+        self.set_policy(Gtk.PolicyType.EXTERNAL, Gtk.PolicyType.NEVER)
+
+        self.scrolling_value: float = 0.0
+        self._scroll_callback_id: Optional[int] = None
+        self._speed: float = self._round_to_nearest_multiple(
+            speed,
+            self.get_hadjustment().get_minimum_increment(),
+        )
+        self._is_visible: bool = is_visible
+
+        self._css_provider = Gtk.CssProvider()
+
+        if text_size is None:
+            self._css_provider.load_from_data(b"")
+        else:
+            self._css_provider.load_from_data(
+                f"""
+                .scrolled_label {{
+                    font-size: {text_size}px
+                }}
+                """.encode()
+            )
+
+        self._label1 = Gtk.Label.new(str=text)
+        self._label1.get_style_context().add_class("scrolled_label")
+        self._label1.get_style_context().add_provider(
+            self._css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+        self._label2 = Gtk.Label.new(str=text)
+        self._label2.get_style_context().add_class("scrolled_label")
+        self._label2.get_style_context().add_provider(
+            self._css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+        self._separator1 = Gtk.Label.new(str=" - ")
+        self._separator1.get_style_context().add_class("scrolled_label")
+        self._separator1.get_style_context().add_provider(
+            self._css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+        self._separator2 = Gtk.Label.new(str=" - ")
+        self._separator2.get_style_context().add_class("scrolled_label")
+        self._separator2.get_style_context().add_provider(
+            self._css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+
+        self._labels_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        self._labels_hbox.pack_start(self._label1, False, False, 0)
+        self._labels_hbox.pack_start(self._separator1, False, False, 0)
+        self._labels_hbox.pack_start(self._label2, False, False, 0)
+        self._labels_hbox.pack_start(self._separator2, False, False, 0)
+
+        self.add(self._labels_hbox)
+
+        if self._is_visible:
+            self._wait_for_self_allocate_and_resize()
+
+    def set_label(self, text: str) -> None:
+        self._label1.set_text(text)
+        self._label2.set_text(text)
+        if self._is_visible:
+            self._resize(
+                self._get_label_width(self._label1),
+                self.get_allocated_width(),
+            )
+
+    def set_markup(self, markup: str) -> None:
+        self._label1.set_markup(markup)
+        self._label2.set_markup(markup)
+        if self._is_visible:
+            self._resize(
+                self._get_label_width(self._label1),
+                self.get_allocated_width(),
+            )
+
+    def set_text_size(self, new_size: Optional[int]) -> None:
+        """
+        set the text size in px, if None use system default
+        """
+        if new_size is None:
+            self._css_provider.load_from_data(b"")
+        else:
+            self._css_provider.load_from_data(
+                f"""
+                .scrolled_label {{
+                    font-size: {new_size}px
+                }}
+                """.encode()
+            )
+        if self._is_visible:
+            self._resize(
+                self._get_label_width(self._label1),
+                self.get_allocated_width(),
+            )
+
+    def set_speed(self, new_speed: float) -> None:
+        self._speed: float = self._round_to_nearest_multiple(
+            new_speed,
+            self.get_hadjustment().get_minimum_increment(),
+        )
+
+    def to_get_visible(self) -> None:
+        """
+        Call this when the label starts to be visible in the ui,
+        it'll start all the animations,
+        see: to_get_invisible()
+        """
+        self._is_visible = True
+        self._wait_for_self_allocate_and_resize()
+
+    def to_get_invisible(self) -> None:
+        """
+        Call this when the label ends being visible in the ui,
+        it'll stop all the animations, to save resources
+        see: to_get_visible()
+        """
+        if self._scroll_callback_id is not None:
+            self.remove_tick_callback(self._scroll_callback_id)
+            self._scroll_callback_id = None
+        self._is_visible = False
+
+    def _resize(self, label_width: int, self_width: int) -> None:
+        if label_width > self_width:
+            self._label2.show()
+            self._separator1.show()
+            self._separator2.show()
+            if self._scroll_callback_id is None:
+                self._scroll_callback_id = self.add_tick_callback(self._scroll, None)
+        else:
+            self._label2.hide()
+            self._separator1.hide()
+            self._separator2.hide()
+            if self._scroll_callback_id is not None:
+                self.remove_tick_callback(self._scroll_callback_id)
+                self._scroll_callback_id = None
+
+    def _scroll(self, *_) -> bool:
+        lower = self.get_hadjustment().get_lower()
+        upper = self.get_hadjustment().get_upper()
+        size = upper - lower
+        self.scrolling_value = ((self.scrolling_value + self._speed) % size) + lower
+
+        if self.scrolling_value > size / 2:
+            self.scrolling_value -= size / 2
+
+        self.get_hadjustment().set_value(self.scrolling_value)
+
+        return True
+
+    def _wait_for_self_allocate_and_resize(self):
+        self._resize(
+            self._get_label_width(self._label1),
+            self.get_allocated_width(),
+        )
+        self.connect("size-allocate", self._size_allocate)
+
+    def _size_allocate(self, _, rect: Gdk.Rectangle):
+        self._resize(
+            self._get_label_width(self._label1),
+            rect.width,
+        )
+        self.disconnect_by_func(self._size_allocate)
+
+    @staticmethod
+    def _get_label_width(label: Gtk.Label) -> int:
+        return label.get_layout().get_pixel_size()[0]
+
+    @staticmethod
+    def _round_to_nearest_multiple(num: float, to: float) -> float:
+        if to == 0:
+            return num
+        return round(num / to) * to
+
+
+class EllipsizedLabel(Gtk.Label):
+    """
+    Elipsized label that can set its text size,
+    if text_size is None, a system default will be used
+    """
+
+    def __init__(self, *args, text_size=None, **kwargs):
+        Gtk.Label.__init__(self, *args, **kwargs)
+
+        self.set_max_width_chars(1)
+        self.set_ellipsize(EllipsizeMode.END)
+
+        self._css_provider = Gtk.CssProvider()
+        if text_size is None:
+            self._css_provider.load_from_data(b"")
+        else:
+            self._css_provider.load_from_data(
+                f"""
+                .sized_label {{
+                    font-size: {text_size}px
+                }}
+                """.encode()
+            )
+
+        self.get_style_context().add_class("sized_label")
+        self.get_style_context().add_provider(
+            self._css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+
+    def set_text_size(self, new_size: Optional[int]) -> None:
+        if new_size is None:
+            self._css_provider.load_from_data(b"")
+        else:
+            self._css_provider.load_from_data(
+                f"""
+                .sized_label {{
+                    font-size: {new_size}px
+                }}
+                """.encode()
+            )

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -168,6 +168,8 @@ class ScrollingLabel(Gtk.ScrolledWindow):
             self._label2.hide()
             self._separator1.hide()
             self._separator2.hide()
+            self.get_hadjustment().set_value(0.0)
+            self.scrolling_value = 0.0
             if self._scroll_callback_id is not None:
                 self.remove_tick_callback(self._scroll_callback_id)
                 self._scroll_callback_id = None

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -47,10 +47,7 @@ class ScrollingLabel(Gtk.ScrolledWindow):
 
         self.scrolling_value: float = 0.0
         self._scroll_callback_id: Optional[int] = None
-        self._speed: float = self._round_to_nearest_multiple(
-            speed,
-            self.get_hadjustment().get_minimum_increment(),
-        )
+        self._speed: float = speed if speed > 0 else 1.0
         self._is_visible: bool = is_visible
 
         self._css_provider = Gtk.CssProvider()
@@ -137,10 +134,8 @@ class ScrollingLabel(Gtk.ScrolledWindow):
             )
 
     def set_speed(self, new_speed: float) -> None:
-        self._speed: float = self._round_to_nearest_multiple(
-            new_speed,
-            self.get_hadjustment().get_minimum_increment(),
-        )
+        if new_speed > 0:
+            self._speed = new_speed
 
     def to_get_visible(self) -> None:
         """
@@ -207,12 +202,6 @@ class ScrollingLabel(Gtk.ScrolledWindow):
     @staticmethod
     def _get_label_width(label: Gtk.Label) -> int:
         return label.get_layout().get_pixel_size()[0]
-
-    @staticmethod
-    def _round_to_nearest_multiple(num: float, to: float) -> float:
-        if to == 0:
-            return num
-        return round(num / to) * to
 
 
 class EllipsizedLabel(Gtk.Label):

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -17,7 +17,7 @@
 
 from SingleAppPlayer import SingleAppPlayer
 from AlbumCoverData import AlbumCoverType
-from Labels import ScrollingLabel, EllipsizedLabel
+from Labels import ScrollingLabel, ElliptedLabel
 from typing import Callable, Optional, Union
 from enum import IntEnum
 import gi
@@ -73,15 +73,11 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.album_cover: Gtk.Image = Gtk.Image.new_from_icon_name(
             "action-unavailable-symbolic", Gtk.IconSize.DIALOG
         )
-        self.song_name_label: Union[ScrollingLabel, EllipsizedLabel] = (
-            ScrollingLabel()
-            if self.text_style == TextStyle.scroll
-            else EllipsizedLabel()
+        self.song_name_label: Union[ScrollingLabel, ElliptedLabel] = (
+            ScrollingLabel() if self.text_style == TextStyle.scroll else ElliptedLabel()
         )
-        self.song_author_label: Union[ScrollingLabel, EllipsizedLabel] = (
-            ScrollingLabel()
-            if self.text_style == TextStyle.scroll
-            else EllipsizedLabel()
+        self.song_author_label: Union[ScrollingLabel, ElliptedLabel] = (
+            ScrollingLabel() if self.text_style == TextStyle.scroll else ElliptedLabel()
         )
         self.song_separator: Gtk.Label = Gtk.Label()
         self.play_pause_button: Gtk.Button = Gtk.Button()
@@ -354,8 +350,8 @@ class PopupPlasmaControlView(SingleAppPlayer):
                 self.song_name_label = ScrollingLabel()
                 self.song_author_label = ScrollingLabel()
             else:
-                self.song_name_label = EllipsizedLabel()
-                self.song_author_label = EllipsizedLabel()
+                self.song_name_label = ElliptedLabel()
+                self.song_author_label = ElliptedLabel()
 
             self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
             self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -17,30 +17,53 @@
 
 from SingleAppPlayer import SingleAppPlayer
 from AlbumCoverData import AlbumCoverType
-from typing import Callable, Optional
+from Labels import ScrollingLabel, EllipsizedLabel
+from typing import Callable, Optional, Union
+from enum import IntEnum
 import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("GLib", "2.0")
 gi.require_version("Gio", "2.0")
 gi.require_version("GdkPixbuf", "2.0")
-gi.require_version("Pango", "1.0")
 from gi.repository import Gtk, GdkPixbuf, GLib, Gio
 from gi.repository.Pango import EllipsizeMode
+
+
+class TextStyle(IntEnum):
+    ellipsis = 0
+    scroll = 1
+
+    @classmethod
+    def insert(cls, value: int, default: int = None):
+        values = list(map(int, cls))
+        if value in values:
+            return cls(value)
+
+        if default in values:
+            return cls(default)
+
+        return cls(values[0])
 
 
 class PopupPlasmaControlView(SingleAppPlayer):
     def __init__(
         self,
         service_name: str,
-        album_cover_size: int,
         open_popover_func: Callable[[], None],
         favorite_clicked: Callable[[str], None],
         settings: Gio.Settings,
     ):
-        self.album_cover_size: int = album_cover_size
+        self.album_cover_size: int = settings.get_uint("popover-album-cover-size")
+        self.text_style: TextStyle = TextStyle.insert(
+            settings.get_uint("plasma-popover-text-style"),
+            default=TextStyle.ellipsis,
+        )
+        settings.connect("changed", self.settings_changed)
 
         self.timers_running: dict[int, bool] = {}
+        self.popover_open: bool = False
+        self.scrolling_text_value: float = 0.0
         self.main_layout_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.info_layout_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.info_layout_hbox.set_homogeneous(True)
@@ -51,8 +74,11 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.album_cover: Gtk.Image = Gtk.Image.new_from_icon_name(
             "action-unavailable-symbolic", Gtk.IconSize.DIALOG
         )
-        self.song_name_label: Gtk.Label = Gtk.Label()
-        self.song_author_label: Gtk.Label = Gtk.Label()
+        self.song_name_label: Union[ScrollingLabel, EllipsizedLabel] = (
+            ScrollingLabel()
+            if self.text_style == TextStyle.scroll
+            else EllipsizedLabel()
+        )
         self.song_author_label: Gtk.Label = Gtk.Label()
         self.song_separator: Gtk.Label = Gtk.Label()
         self.play_pause_button: Gtk.Button = Gtk.Button()
@@ -77,11 +103,8 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.info_layout_hbox.pack_start(self.album_cover, False, False, 0)
 
         # song name label
-        self.song_name_label.set_max_width_chars(1)
-        self.song_name_label.set_hexpand(True)
-        self.song_name_label.set_ellipsize(EllipsizeMode.END)
-        self._set_title(self.title)
         self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
+        self._set_title(self.title)
 
         # song progress label
         progress_bar_layout.pack_start(self.progress_label, False, False, 4)
@@ -188,9 +211,15 @@ class PopupPlasmaControlView(SingleAppPlayer):
 
     # overridden parent method
     def popover_to_be_open(self) -> None:
+        self.popover_open = True
+        if self.text_style == TextStyle.scroll:
+            self.song_name_label.to_get_visible()
         self._create_timer()
 
     def popover_just_closed(self) -> None:
+        self.popover_open = False
+        if self.text_style == TextStyle.scroll:
+            self.song_name_label.to_get_invisible()
         for key in self.timers_running:
             self.timers_running[key] = False
 
@@ -295,6 +324,23 @@ class PopupPlasmaControlView(SingleAppPlayer):
                 self.album_cover_data.song_cover_other,
                 Gtk.IconSize.DIALOG,
             )
+
+    def settings_changed(self, settings: Gio.Settings, changed_key: str) -> None:
+        if changed_key == "plasma-popover-text-style":
+            style = TextStyle.insert(settings.get_uint("plasma-popover-text-style"))
+            if style == self.text_style:
+                return
+            self.text_style = style
+            self.song_name_label.destroy()
+            if self.text_style == TextStyle.scroll:
+                self.song_name_label = ScrollingLabel()
+            else:
+                self.song_name_label = EllipsizedLabel()
+
+            self.song_name_label.show_all()
+            self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
+            self.info_layout_vbox.reorder_child(self.song_name_label, 0)
+            self._set_title(self.title)
 
     def _create_timer(self) -> None:
         for key in self.timers_running:

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -79,7 +79,11 @@ class PopupPlasmaControlView(SingleAppPlayer):
             if self.text_style == TextStyle.scroll
             else EllipsizedLabel()
         )
-        self.song_author_label: Gtk.Label = Gtk.Label()
+        self.song_author_label: Union[ScrollingLabel, EllipsizedLabel] = (
+            ScrollingLabel()
+            if self.text_style == TextStyle.scroll
+            else EllipsizedLabel()
+        )
         self.song_separator: Gtk.Label = Gtk.Label()
         self.play_pause_button: Gtk.Button = Gtk.Button()
         self.go_previous_button: Gtk.Button = Gtk.Button()
@@ -103,8 +107,8 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.info_layout_hbox.pack_start(self.album_cover, False, False, 0)
 
         # song name label
-        self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
         self._set_title(self.title)
+        self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
 
         # song progress label
         progress_bar_layout.pack_start(self.progress_label, False, False, 4)
@@ -117,9 +121,6 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self._set_progress_label_and_bar()
 
         # song author label
-        self.song_author_label.set_max_width_chars(1)
-        self.song_author_label.set_hexpand(True)
-        self.song_author_label.set_ellipsize(EllipsizeMode.END)
         self.song_author_label.set_label(", ".join(self.artist))
         self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
 
@@ -214,12 +215,14 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.popover_open = True
         if self.text_style == TextStyle.scroll:
             self.song_name_label.to_get_visible()
+            self.song_author_label.to_get_visible()
         self._create_timer()
 
     def popover_just_closed(self) -> None:
         self.popover_open = False
         if self.text_style == TextStyle.scroll:
             self.song_name_label.to_get_invisible()
+            self.song_author_label.to_get_invisible()
         for key in self.timers_running:
             self.timers_running[key] = False
 
@@ -332,15 +335,20 @@ class PopupPlasmaControlView(SingleAppPlayer):
                 return
             self.text_style = style
             self.song_name_label.destroy()
+            self.song_author_label.destroy()
             if self.text_style == TextStyle.scroll:
                 self.song_name_label = ScrollingLabel()
+                self.song_author_label = ScrollingLabel()
             else:
                 self.song_name_label = EllipsizedLabel()
+                self.song_author_label = EllipsizedLabel()
 
             self.song_name_label.show_all()
             self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
-            self.info_layout_vbox.reorder_child(self.song_name_label, 0)
+            self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
+            self.info_layout_vbox.show_all()
             self._set_title(self.title)
+            self.song_author_label.set_label(", ".join(self.artist))
 
     def _create_timer(self) -> None:
         for key in self.timers_running:

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -110,6 +110,10 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.song_name_label.set_text_size(
             None if song_name_size < 0 else song_name_size
         )
+        if self.text_style == TextStyle.scroll:
+            speed = settings.get_double("plasma-popover-media-name-scrolling-speed")
+            self.song_name_label.set_speed(speed)
+
         self._set_title(self.title)
         self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
 
@@ -128,6 +132,9 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.song_author_label.set_text_size(
             None if author_name_size < 0 else author_name_size
         )
+        if self.text_style == TextStyle.scroll:
+            speed = settings.get_double("plasma-popover-media-author-scrolling-speed")
+            self.song_author_label.set_speed(speed)
         self.song_author_label.set_label(", ".join(self.artist))
         self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
 
@@ -373,6 +380,20 @@ class PopupPlasmaControlView(SingleAppPlayer):
         if changed_key == "plasma-popover-media-author-size":
             size = settings.get_int("plasma-popover-media-author-size")
             self.song_author_label.set_text_size(None if size < 0 else size)
+            return
+
+        if changed_key == "plasma-popover-media-name-scrolling-speed":
+            if self.text_style != TextStyle.scroll:
+                return
+            speed = settings.get_double("plasma-popover-media-name-scrolling-speed")
+            self.song_name_label.set_speed(speed)
+            return
+
+        if changed_key == "plasma-popover-media-author-scrolling-speed":
+            if self.text_style != TextStyle.scroll:
+                return
+            speed = settings.get_double("plasma-popover-media-author-scrolling-speed")
+            self.song_author_label.set_speed(speed)
             return
 
     def _create_timer(self) -> None:

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -113,6 +113,8 @@ class PopupPlasmaControlView(SingleAppPlayer):
         if self.text_style == TextStyle.scroll:
             speed = settings.get_double("plasma-popover-media-name-scrolling-speed")
             self.song_name_label.set_speed(speed)
+        else:
+            self.song_name_label.set_xalign(0.0)
 
         self._set_title(self.title)
         self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
@@ -135,6 +137,9 @@ class PopupPlasmaControlView(SingleAppPlayer):
         if self.text_style == TextStyle.scroll:
             speed = settings.get_double("plasma-popover-media-author-scrolling-speed")
             self.song_author_label.set_speed(speed)
+        else:
+            self.song_author_label.set_xalign(0.0)
+
         self.song_author_label.set_label(", ".join(self.artist))
         self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
 
@@ -356,6 +361,8 @@ class PopupPlasmaControlView(SingleAppPlayer):
             else:
                 self.song_name_label = EllipsizedLabel()
                 self.song_author_label = EllipsizedLabel()
+                self.song_name_label.set_xalign(0.0)
+                self.song_author_label.set_xalign(0.0)
 
             self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
             self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -34,7 +34,7 @@ class TextStyle(IntEnum):
     scroll = 1
 
     @classmethod
-    def insert(cls, value: int, default: int = None):
+    def insert(cls, value: int, default: Optional[int] = None):
         values = list(map(int, cls))
         if value in values:
             return cls(value)

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -113,8 +113,6 @@ class PopupPlasmaControlView(SingleAppPlayer):
         if self.text_style == TextStyle.scroll:
             speed = settings.get_double("plasma-popover-media-name-scrolling-speed")
             self.song_name_label.set_speed(speed)
-        else:
-            self.song_name_label.set_xalign(0.0)
 
         self._set_title(self.title)
         self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
@@ -137,9 +135,6 @@ class PopupPlasmaControlView(SingleAppPlayer):
         if self.text_style == TextStyle.scroll:
             speed = settings.get_double("plasma-popover-media-author-scrolling-speed")
             self.song_author_label.set_speed(speed)
-        else:
-            self.song_author_label.set_xalign(0.0)
-
         self.song_author_label.set_label(", ".join(self.artist))
         self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
 
@@ -361,8 +356,6 @@ class PopupPlasmaControlView(SingleAppPlayer):
             else:
                 self.song_name_label = EllipsizedLabel()
                 self.song_author_label = EllipsizedLabel()
-                self.song_name_label.set_xalign(0.0)
-                self.song_author_label.set_xalign(0.0)
 
             self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
             self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -27,7 +27,6 @@ gi.require_version("GLib", "2.0")
 gi.require_version("Gio", "2.0")
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gtk, GdkPixbuf, GLib, Gio
-from gi.repository.Pango import EllipsizeMode
 
 
 class TextStyle(IntEnum):
@@ -107,6 +106,10 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self.info_layout_hbox.pack_start(self.album_cover, False, False, 0)
 
         # song name label
+        song_name_size = settings.get_int("plasma-popover-media-name-size")
+        self.song_name_label.set_text_size(
+            None if song_name_size < 0 else song_name_size
+        )
         self._set_title(self.title)
         self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
 
@@ -121,6 +124,10 @@ class PopupPlasmaControlView(SingleAppPlayer):
         self._set_progress_label_and_bar()
 
         # song author label
+        author_name_size = settings.get_int("plasma-popover-media-author-size")
+        self.song_author_label.set_text_size(
+            None if author_name_size < 0 else author_name_size
+        )
         self.song_author_label.set_label(", ".join(self.artist))
         self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
 
@@ -343,12 +350,30 @@ class PopupPlasmaControlView(SingleAppPlayer):
                 self.song_name_label = EllipsizedLabel()
                 self.song_author_label = EllipsizedLabel()
 
-            self.song_name_label.show_all()
             self.info_layout_vbox.pack_start(self.song_name_label, False, False, 0)
             self.info_layout_vbox.pack_start(self.song_author_label, False, False, 0)
             self.info_layout_vbox.show_all()
+
+            name_size = settings.get_int("plasma-popover-media-name-size")
+            author_size = settings.get_int("plasma-popover-media-author-size")
+            self.song_name_label.set_text_size(None if name_size < 0 else name_size)
+            self.song_author_label.set_text_size(
+                None if author_size < 0 else author_size
+            )
+
             self._set_title(self.title)
             self.song_author_label.set_label(", ".join(self.artist))
+            return
+
+        if changed_key == "plasma-popover-media-name-size":
+            size = settings.get_int("plasma-popover-media-name-size")
+            self.song_name_label.set_text_size(None if size < 0 else size)
+            return
+
+        if changed_key == "plasma-popover-media-author-size":
+            size = settings.get_int("plasma-popover-media-author-size")
+            self.song_author_label.set_text_size(None if size < 0 else size)
+            return
 
     def _create_timer(self) -> None:
         for key in self.timers_running:

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -160,9 +160,7 @@ class MainPage(Gtk.Grid):
         )
 
         self.popover_text_style_combobox = Gtk.ComboBoxText.new()
-        self.popover_text_style_combobox.append(
-            "0", "Ellipt (Cut)"
-        )
+        self.popover_text_style_combobox.append("0", "Ellipt (Cut)")
         self.popover_text_style_combobox.append("1", "Scroll")
         self.popover_text_style_combobox.set_active_id(
             str(self.settings.get_uint("plasma-popover-text-style"))

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -160,7 +160,9 @@ class MainPage(Gtk.Grid):
         )
 
         self.popover_text_style_combobox = Gtk.ComboBoxText.new()
-        self.popover_text_style_combobox.append("0", "Elipsize")
+        self.popover_text_style_combobox.append(
+            "0", "Ellipt (Cut)"
+        )
         self.popover_text_style_combobox.append("1", "Scroll")
         self.popover_text_style_combobox.set_active_id(
             str(self.settings.get_uint("plasma-popover-text-style"))

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -153,6 +153,95 @@ class MainPage(Gtk.Grid):
         )
         size_info_label.set_max_width_chars(1)
 
+        popover_text_style_label = Gtk.Label(
+            label="Popup text style:",
+            tooltip_text="Style of the name and author text in the popup",
+            halign=Gtk.Align.START,
+        )
+
+        self.popover_text_style_combobox = Gtk.ComboBoxText.new()
+        self.popover_text_style_combobox.append("0", "Elipsize")
+        self.popover_text_style_combobox.append("1", "Scroll")
+        self.popover_text_style_combobox.set_active_id(
+            str(self.settings.get_uint("plasma-popover-text-style"))
+        )
+        self.popover_text_style_combobox.connect(
+            "changed", self.popover_text_style_combobox_changed
+        )
+
+        popover_text_size_label = Gtk.Label(halign=Gtk.Align.START)
+        popover_text_size_label.set_markup("<b>Size of the text in popup:</b>")
+
+        popover_text_size_name_label, popover_text_size_name_spinbox = (
+            self._combobox_label_init(
+                "   - Name:",
+                "Size of the name text in the popup, -1 is default",
+                "plasma-popover-media-name-size",
+                -1,
+                200,
+            )
+        )
+        popover_text_size_author_label, popover_text_size_author_spinbox = (
+            self._combobox_label_init(
+                "   - Author:",
+                "Size of the author text in the popup, -1 is default",
+                "plasma-popover-media-author-size",
+                -1,
+                200,
+            )
+        )
+
+        popover_scrolling_speed_label = Gtk.Label(halign=Gtk.Align.START)
+        popover_scrolling_speed_label.set_markup(
+            "<b>Text scrolling speed in popup:</b>"
+        )
+
+        popover_scrolling_speed_name_label = Gtk.Label(
+            label="   - Name:",
+            tooltip_text="Speed of the scrolling of the name text in the popup, "
+            "if text style set to scrolling",
+            halign=Gtk.Align.START,
+        )
+
+        popover_scrolling_speed_name_spinbox = Gtk.SpinButton.new_with_range(1, 200, 1)
+        popover_scrolling_speed_name_spinbox.set_value(
+            round(
+                self.settings.get_double("plasma-popover-media-name-scrolling-speed")
+                * 4
+            )
+        )
+        popover_scrolling_speed_name_spinbox.connect(
+            "value-changed",
+            lambda *_: self.settings.set_double(
+                "plasma-popover-media-name-scrolling-speed",
+                popover_scrolling_speed_name_spinbox.get_value_as_int() / 4,
+            ),
+        )
+
+        popover_scrolling_speed_author_label = Gtk.Label(
+            label="   - Author:",
+            tooltip_text="Speed of the scrolling of the author text in the popup, "
+            "if text style set to scrolling",
+            halign=Gtk.Align.START,
+        )
+
+        popover_scrolling_speed_author_spinbox = Gtk.SpinButton.new_with_range(
+            1, 200, 1
+        )
+        popover_scrolling_speed_author_spinbox.set_value(
+            round(
+                self.settings.get_double("plasma-popover-media-author-scrolling-speed")
+                * 4
+            )
+        )
+        popover_scrolling_speed_author_spinbox.connect(
+            "value-changed",
+            lambda *_: self.settings.set_double(
+                "plasma-popover-media-author-scrolling-speed",
+                popover_scrolling_speed_author_spinbox.get_value_as_int() / 4,
+            ),
+        )
+
         self.attach(max_len_title, 0, 0, 2, 1)
         self.attach(self.name_max_len_label, 0, 1, 1, 1)
         self.attach(self.name_max_len_spin_button, 1, 1, 1, 1)
@@ -171,6 +260,19 @@ class MainPage(Gtk.Grid):
         self.attach(popover_album_cover_size_label, 0, 9, 1, 1)
         self.attach(self.popover_album_cover_size_combobox, 1, 9, 1, 1)
         self.attach(size_info_label, 0, 10, 2, 1)
+        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 11, 2, 1)
+        self.attach(popover_text_style_label, 0, 12, 1, 1)
+        self.attach(self.popover_text_style_combobox, 1, 12, 1, 1)
+        self.attach(popover_text_size_label, 0, 13, 2, 1)
+        self.attach(popover_text_size_name_label, 0, 14, 1, 1)
+        self.attach(popover_text_size_name_spinbox, 1, 14, 1, 1)
+        self.attach(popover_text_size_author_label, 0, 15, 1, 1)
+        self.attach(popover_text_size_author_spinbox, 1, 15, 1, 1)
+        self.attach(popover_scrolling_speed_label, 0, 16, 2, 1)
+        self.attach(popover_scrolling_speed_name_label, 0, 17, 1, 1)
+        self.attach(popover_scrolling_speed_name_spinbox, 1, 17, 1, 1)
+        self.attach(popover_scrolling_speed_author_label, 0, 18, 1, 1)
+        self.attach(popover_scrolling_speed_author_spinbox, 1, 18, 1, 1)
 
         self.show_all()
 
@@ -190,7 +292,17 @@ class MainPage(Gtk.Grid):
         self.settings.set_boolean("show-arrow", state)
         return False
 
-    def settings_changed(self, settings, key):
+    def popover_text_style_combobox_changed(self, *_) -> None:
+        new_val = self.popover_text_style_combobox.get_active_id()
+        if not new_val.isdigit():
+            return
+        num_val = int(new_val)
+        if num_val < 0:
+            return
+        self.settings.set_uint("plasma-popover-text-style", num_val)
+
+    def settings_changed(self, _, key):
+        # note: this isn't really needed you will not change settings from two places at once
         if key == "author-name-max-length":
             self.author_max_len_spin_button.set_value(self.settings.get_int(key))
             return

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,5 +7,6 @@ install_data(
     'AlbumCoverData.py',
     'mprisWrapper.py',
     'SettingsPage.py',
+    'Labels.py',
     install_dir: PLUGINS_INSTALL_DIR
 )


### PR DESCRIPTION
Added more options to the popover, some from #8 

### New:
- Created two styles for the text in the popup
  - One is the old way, where the text is cut and ends with an ellipsis
  - The other is that the text is scrolling, when too long
- Made the size of the text in the popup customizable
  - The size of the song's name is independent of the size of the author's name 
- When the text is scrolling you can set the scrolling speed 

### Note: 
The settings for the new options are not very polished and have many flaws, but i plan doing a settings redesign, so these are to just have something. 