### PR TITLE
Make scrolling in the popup non default

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -45,7 +45,7 @@
         <key type="u" name="plasma-popover-text-style">
             <summary>Style of the name and author text in the plasma popover</summary>
             <description>Style of the name and author text in the plasma popover, ellipting: 0, scrolling (marquee): 1.</description>
-            <default>1</default>
+            <default>0</default>
         </key>
         <key type="i" name="plasma-popover-media-name-size">
             <summary>Size of the name text in the plasma popover</summary>

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -297,7 +297,7 @@ class PopoverSettingsPage(_SettingsPageBase):
 
         text_style_combobox = Gtk.ComboBoxText()
         text_style_combobox.append("0", "Ellipt (Cut)")
-        text_style_combobox.append("1", "Scroll")
+        text_style_combobox.append("1", "Scroll, may be laggy")
         text_style_combobox.set_active_id(
             str(self.settings.get_uint("plasma-popover-text-style"))
         )


### PR DESCRIPTION
## Change:
Change "scroll" to "scroll, may be laggy" in settings in the option that sets the text in the popup to scroll. Make the default popup text style to "Ellipt".

## Reason:
The scrolling is laggy and uses a lot of cpu, see: #12
So I make it non default and add a warning.

