### PR TITLE
Improve popup album size

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -37,10 +37,10 @@
             <description>The height of the popover in px.</description>
             <default>400</default>
         </key>
-        <key type="u" name="popover-album-cover-size">
+        <key type="d" name="popover-album-cover-size">
             <summary>Size of the album cover in the popover</summary>
-            <description>Size of the album cover's bigger side in px.</description>
-            <default>180</default>
+            <description>Portion of the availible space, from 0 to 1.</description>
+            <default>0.9</default>
         </key>
         <key type="u" name="plasma-popover-text-style">
             <summary>Style of the name and author text in the plasma popover</summary>

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -33,9 +33,6 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.separator_text: str = self.settings.get_string("separator-text")
         self.popover_width: int = self.settings.get_uint("popover-width")
         self.popover_height: int = self.settings.get_uint("popover-height")
-        self.popover_album_cover_size: int = self.settings.get_uint(
-            "popover-album-cover-size"
-        )
 
         self.box: Gtk.Box = Gtk.Box(spacing=10)
         self.add(self.box)
@@ -270,7 +267,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         if changed_key_name == "popover-album-cover-size":
             for player in self.players_list.values():
                 player.set_popover_album_cover_size(
-                    self.settings.get_uint("popover-album-cover-size")
+                    self.settings.get_double("popover-album-cover-size")
                 )
             return
 

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -263,20 +263,22 @@ class PopoverSettingsPage(_SettingsPageBase):
 
         cover_size_label = LabelWSubtitle(
             title="Album cover size:",
-            subtitle="Size of the album cover",
+            subtitle="Percentage of available space",
         )
         cover_size_scale = Gtk.Scale.new_with_range(
             Gtk.Orientation.HORIZONTAL,
-            min=40,
-            max=500,
+            min=1,
+            max=100,
             step=1,
         )
         cover_size_scale.set_hexpand(True)
-        cover_size_scale.set_value(self.settings.get_uint("popover-album-cover-size"))
+        cover_size_scale.set_value(
+            round(self.settings.get_double("popover-album-cover-size") * 100)
+        )
         cover_size_scale.connect(
             "value-changed",
-            lambda slider: self.settings.set_uint(
-                "popover-album-cover-size", round(slider.get_value())
+            lambda slider: self.settings.set_double(
+                "popover-album-cover-size", round(slider.get_value() / 100, 2)
             ),
         )
 

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -282,16 +282,6 @@ class PopoverSettingsPage(_SettingsPageBase):
             ),
         )
 
-        cover_size_note = Gtk.Label(
-            label='Note: <span weight="light">'
-            "If the selected album cover size is larger than "
-            "the popup dimensions the popup will be automatically expanded</span>",
-            use_markup=True,
-            wrap=True,
-            max_width_chars=1,
-            xalign=0.0,
-        )
-
         text_style_label = LabelWSubtitle(
             title="Popup text style:",
             subtitle="Style of the text in the popup",
@@ -438,33 +428,29 @@ class PopoverSettingsPage(_SettingsPageBase):
         self.attach(width_scale, 1, 0, 1, 1)
         self.attach(height_label, 0, 1, 1, 1)
         self.attach(height_scale, 1, 1, 1, 1)
+        self.attach(cover_size_label, 0, 2, 1, 1)
+        self.attach(cover_size_scale, 1, 2, 1, 1)
 
-        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 2, 2, 1)
+        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 3, 2, 1)
 
-        self.attach(cover_size_label, 0, 3, 1, 1)
-        self.attach(cover_size_scale, 1, 3, 1, 1)
-        self.attach(cover_size_note, 0, 4, 2, 1)
+        self.attach(text_style_label, 0, 4, 1, 1)
+        self.attach(text_style_combobox, 1, 4, 1, 1)
 
         self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 5, 2, 1)
 
-        self.attach(text_style_label, 0, 6, 1, 1)
-        self.attach(text_style_combobox, 1, 6, 1, 1)
+        self.attach(text_size_label, 0, 6, 2, 1)
+        self.attach(name_text_size_box, 0, 7, 1, 1)
+        self.attach(name_text_size_spin, 1, 7, 1, 1)
+        self.attach(author_text_size_box, 0, 8, 1, 1)
+        self.attach(author_text_size_spin, 1, 8, 1, 1)
 
-        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 7, 2, 1)
+        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 9, 2, 1)
 
-        self.attach(text_size_label, 0, 8, 2, 1)
-        self.attach(name_text_size_box, 0, 9, 1, 1)
-        self.attach(name_text_size_spin, 1, 9, 1, 1)
-        self.attach(author_text_size_box, 0, 10, 1, 1)
-        self.attach(author_text_size_spin, 1, 10, 1, 1)
-
-        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 11, 2, 1)
-
-        self.attach(scrolling_speed_label, 0, 12, 2, 1)
-        self.attach(scrolling_speed_name_label, 0, 13, 1, 1)
-        self.attach(self.scrolling_speed_name_scale, 1, 13, 1, 1)
-        self.attach(scrolling_speed_author_label, 0, 14, 1, 1)
-        self.attach(self.scrolling_speed_author_scale, 1, 14, 1, 1)
+        self.attach(scrolling_speed_label, 0, 10, 2, 1)
+        self.attach(scrolling_speed_name_label, 0, 11, 1, 1)
+        self.attach(self.scrolling_speed_name_scale, 1, 11, 1, 1)
+        self.attach(scrolling_speed_author_label, 0, 12, 1, 1)
+        self.attach(self.scrolling_speed_author_scale, 1, 12, 1, 1)
 
     def text_style_combo_changed(self, combo: Gtk.ComboBox) -> None:
         value = 0

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -487,3 +487,33 @@ class SingleAppPlayer(Gtk.Bin):
                         return
 
         self.icon.set_from_icon_name("multimedia-player-symbolic", self.ICON_SIZE)
+
+    def _get_resized_pixbuf(
+        self, available_height: int, available_width: int, portion_to_fill: float
+    ) -> GdkPixbuf:
+        square_size = min(
+            available_height,
+            round(available_width * portion_to_fill),
+        )
+        if (
+            self.album_cover_data.song_cover_pixbuf.get_width()
+            < self.album_cover_data.song_cover_pixbuf.get_height()
+        ):
+            resized_pixbuf = self.album_cover_data.song_cover_pixbuf.scale_simple(
+                int(
+                    (square_size / self.album_cover_data.song_cover_pixbuf.get_height())
+                    * self.album_cover_data.song_cover_pixbuf.get_width()
+                ),
+                square_size,
+                GdkPixbuf.InterpType.BILINEAR,
+            )
+        else:
+            resized_pixbuf = self.album_cover_data.song_cover_pixbuf.scale_simple(
+                square_size,
+                int(
+                    (square_size / self.album_cover_data.song_cover_pixbuf.get_width())
+                    * self.album_cover_data.song_cover_pixbuf.get_height()
+                ),
+                GdkPixbuf.InterpType.BILINEAR,
+            )
+        return resized_pixbuf


### PR DESCRIPTION
## Changes
Make album cover size setting a portion of available space instead of a fixed size.
That means that the popup will no longer get larger than its size when album size is too big.
The note about album sizing was removed as it is no longer needed.

## Reason
It makes the settings simpler, and easier to understand.
Also you don't have to adjust two sliders when resizing. 