### PR TITLE
Refactoring and moving

### DIFF
--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -212,13 +212,6 @@ class BudgieMediaPlayer(Budgie.Applet):
             self.popover.set_size_request(self.popover_width, self.popover_height)
             return
 
-        if changed_key_name == "popover-album-cover-size":
-            for player in self.players_list.values():
-                player.set_popover_album_cover_size(
-                    self.settings.get_double("popover-album-cover-size")
-                )
-            return
-
     def do_panel_size_changed(
         self, panel_size: int, icon_size: int, small_icon_size: int
     ) -> None:

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -211,8 +211,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         """Return the applet settings with given uuid"""
         return SettingsPage(self.settings)
 
-    @staticmethod
-    def do_supports_settings():
+    def do_supports_settings(self):
         """Return True if support setting through Budgie Setting,
         False otherwise."""
         return True

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -88,10 +88,6 @@ class BudgieMediaPlayer(Budgie.Applet):
             )
             if len(self.players_list) < 1:
                 new_view.add_panel_view(
-                    author_max_len=self.author_max_len,
-                    title_max_len=self.name_max_len,
-                    separator_text=self.separator_text,
-                    element_order=self.element_order,
                     orientation=self.orientation,
                 )
                 self.box.pack_start(new_view.panel_view, False, False, 0)
@@ -127,10 +123,6 @@ class BudgieMediaPlayer(Budgie.Applet):
 
                 self.players_list[service_name].remove_panel_view()
                 value.add_panel_view(
-                    author_max_len=self.author_max_len,
-                    title_max_len=self.name_max_len,
-                    separator_text=self.separator_text,
-                    element_order=self.element_order,
                     orientation=self.orientation,
                 )
                 self.box.pack_start(value.panel_view, False, False, 0)
@@ -141,10 +133,6 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.players_list[self.panel_player_service_name].remove_panel_view()
 
         self.players_list[service_name].add_panel_view(
-            author_max_len=self.author_max_len,
-            title_max_len=self.name_max_len,
-            separator_text=self.separator_text,
-            element_order=self.element_order,
             orientation=self.orientation,
         )
         self.box.pack_start(self.players_list[service_name].panel_view, False, False, 0)
@@ -181,10 +169,6 @@ class BudgieMediaPlayer(Budgie.Applet):
             if len(self.players_list) < 1:
                 self.panel_player_service_name = new_view.service_name
                 new_view.add_panel_view(
-                    author_max_len=self.author_max_len,
-                    title_max_len=self.name_max_len,
-                    separator_text=self.separator_text,
-                    element_order=self.element_order,
                     orientation=self.orientation,
                 )
                 self.box.pack_start(new_view.panel_view, False, False, 0)
@@ -206,10 +190,6 @@ class BudgieMediaPlayer(Budgie.Applet):
             if len(self.players_list) > 0:
                 for player in self.players_list.values():
                     player.add_panel_view(
-                        author_max_len=self.author_max_len,
-                        title_max_len=self.name_max_len,
-                        separator_text=self.separator_text,
-                        element_order=self.element_order,
                         orientation=self.orientation,
                     )
                     self.box.pack_start(player.panel_view, False, False, 0)
@@ -219,38 +199,6 @@ class BudgieMediaPlayer(Budgie.Applet):
                 self.panel_player_service_name = None
 
     def settings_changed(self, _, changed_key_name: str) -> None:
-        if changed_key_name == "author-name-max-length":
-            self.author_max_len = self.settings.get_int(changed_key_name)
-            if (
-                player := self.players_list.get(self.panel_player_service_name, None)
-            ) is not None:
-                player.set_author_max_len(self.author_max_len)
-            return
-
-        if changed_key_name == "media-title-max-length":
-            self.name_max_len = self.settings.get_int(changed_key_name)
-            if (
-                player := self.players_list.get(self.panel_player_service_name, None)
-            ) is not None:
-                player.set_title_max_len(self.name_max_len)
-            return
-
-        if changed_key_name == "element-order":
-            self.element_order = self.settings.get_strv(changed_key_name)
-            if (
-                player := self.players_list.get(self.panel_player_service_name, None)
-            ) is not None:
-                player.set_element_order(self.element_order)
-            return
-
-        if changed_key_name == "separator-text":
-            self.separator_text = self.settings.get_string("separator-text")
-            if (
-                player := self.players_list.get(self.panel_player_service_name, None)
-            ) is not None:
-                player.set_separator_text(self.separator_text)
-            return
-
         if changed_key_name == "show-arrow":
             if self.settings.get_boolean("show-arrow"):
                 self.popup_icon.show()

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -212,10 +212,6 @@ class PopupPlasmaControlView(SingleAppPlayer):
     def pin_clicked(self, *_) -> None:
         self.on_pin_clicked(self.service_name)
 
-    def set_popover_album_cover_size(self, new_size: float) -> None:
-        self.album_cover_size = new_size
-        self.album_cover_changed()
-
     # overridden parent method
     def popover_to_be_open(self) -> None:
         self.popover_open = True
@@ -320,6 +316,10 @@ class PopupPlasmaControlView(SingleAppPlayer):
             )
 
     def settings_changed(self, settings: Gio.Settings, changed_key: str) -> None:
+        if changed_key == "popover-album-cover-size":
+            self.album_cover_size = self.settings.get_double("popover-album-cover-size")
+            self.album_cover_changed()
+
         if changed_key == "plasma-popover-text-style":
             style = TextStyle.insert(settings.get_uint("plasma-popover-text-style"))
             if style == self.text_style:

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -143,10 +143,6 @@ class SingleAppPlayer(Gtk.Bin):
 
     def add_panel_view(
         self,
-        author_max_len: int,
-        title_max_len: int,
-        separator_text: str,
-        element_order: list[str],
         orientation: Gtk.Orientation,
     ) -> None:
         self.panel_view = PanelControlView(
@@ -159,11 +155,8 @@ class SingleAppPlayer(Gtk.Bin):
             can_go_previous=self.can_go_previous,
             can_go_next=self.can_go_next,
             open_popover_func=self.open_popover_func,
-            author_max_len=author_max_len,
-            title_max_len=title_max_len,
-            separator_text=separator_text,
-            element_order=element_order,
             orientation=orientation,
+            settings=self.settings,
         )
 
         self.pinned_changed()
@@ -186,24 +179,6 @@ class SingleAppPlayer(Gtk.Bin):
     def panel_orientation_changed(self, new_orientation: Gtk.Orientation) -> None:
         if self.panel_view is not None:
             self.panel_view.set_orientation(new_orientation)
-
-    def set_author_max_len(self, new_length: int) -> None:
-        if self.panel_view is not None:
-            self.panel_view.author_max_len = new_length
-            self.panel_view.set_metadata(self.artist, self.title)
-
-    def set_title_max_len(self, new_length: int) -> None:
-        if self.panel_view is not None:
-            self.panel_view.name_max_len = new_length
-            self.panel_view.set_metadata(self.artist, self.title)
-
-    def set_separator_text(self, new_separator: str) -> None:
-        if self.panel_view is not None:
-            self.panel_view.set_separator_text(new_separator)
-
-    def set_element_order(self, new_order: list[str]) -> None:
-        if self.panel_view is not None:
-            self.panel_view.set_element_order(new_order)
 
     def set_popover_album_cover_size(self, new_size: int) -> None:
         pass

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -180,9 +180,6 @@ class SingleAppPlayer(Gtk.Bin):
         if self.panel_view is not None:
             self.panel_view.set_orientation(new_orientation)
 
-    def set_popover_album_cover_size(self, new_size: int) -> None:
-        pass
-
     def popover_to_be_open(self) -> None:
         pass
 


### PR DESCRIPTION
1. **Moved settings handling for PanelControlView.py:** Improved readability by moving settings handling directly to PanelControlView. Ellipsis of labels now done through GTK.

2. **Move settings changes for "popover-album-cover-size" to PopupPlasmaControlView.py.**

3. **Refactor and simplify BudgieMediaPlayer.py:** Removed unused variables, created reusable functions, and performed general refactoring.

4. **Made some methods in PanelControlView private.**

_For more info, see individual commit messages_
