### PR TITLE
Better panel sizing

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema id="com.github.zalesyc.budgie-media-player-applet">
-        <!--TODO: improve/add descriptions -->
-        <key type="u" name="panel-length-type">
-            <summary>How to set the panel length</summary>
-            <description>no limit: 0, 1: variable, 2: fixed</description>
-	        <default>0</default>
+        <key type="u" name="panel-length-mode">
+            <summary>Panel length mode</summary>
+            <description>: 0: No limit, 1: Variable / Max length, 2: Fixed</description>
+	        <default>1</default>
         </key>
-        <key type="u" name="panel-max-length">
-            <summary>Length of the applet</summary>
-            <description>TODO</description>
-	        <default>200</default>
+        <key type="u" name="panel-length-fixed">
+            <summary>Length of the applet when mode set to Fixed (0)</summary>
+            <description> </description>
+	        <default>300</default>
         </key>
         <key type="i" name="author-name-max-length">
             <summary>Maximum length of author's name</summary>
-            <description>The maximum length, in characters, of the playing media author's name, if less than 0, set an unlimited length.</description>
+            <description>The maximum length, in characters, of the playing media author's name, if less than 0, set an unlimited length. This value is only used when panel-length-mode is set to Variable (1)</description>
 	        <default>25</default>
         </key>
 
         <key type="i" name="media-title-max-length">
             <summary>Maximum length of the playing media's title</summary>
-            <description>The maximum length, in characters, of the playing media's title, if less than 0, set an unlimited length.</description>
+            <description>The maximum length, in characters, of the playing media's title, if less than 0, set an unlimited length. This value is only used when panel-length-mode is set to Variable (1)</description>
 	        <default>40</default>
         </key>
         <key type="as" name="element-order">

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
     <schema id="com.github.zalesyc.budgie-media-player-applet">
+        <!--TODO: improve/add descriptions -->
+        <key type="u" name="panel-length-type">
+            <summary>How to set the panel length</summary>
+            <description>no limit: 0, 1: variable, 2: fixed</description>
+	        <default>0</default>
+        </key>
+        <key type="u" name="panel-max-length">
+            <summary>Length of the applet</summary>
+            <description>TODO</description>
+	        <default>200</default>
+        </key>
         <key type="i" name="author-name-max-length">
             <summary>Maximum length of author's name</summary>
             <description>The maximum length, in characters, of the playing media author's name, if less than 0, set an unlimited length.</description>

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -3,12 +3,12 @@
     <schema id="com.github.zalesyc.budgie-media-player-applet">
         <key type="u" name="panel-length-mode">
             <summary>Panel length mode</summary>
-            <description>: 0: No limit, 1: Variable / Max length, 2: Fixed</description>
+            <description>Mode for how the applet in the panel is sized: 0: No limit, 1: Variable / Max length, 2: Fixed.</description>
 	        <default>1</default>
         </key>
         <key type="u" name="panel-length-fixed">
             <summary>Length of the applet when mode set to Fixed (0)</summary>
-            <description> </description>
+            <description>Length of the applet when mode is set to Fixed (0), the size is in pixels.</description>
 	        <default>300</default>
         </key>
         <key type="i" name="author-name-max-length">

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -6,6 +6,7 @@ import gi
 from SettingsPage import SettingsPage
 from PopupPlasmaControlView import PopupPlasmaControlView
 from EnumsStructs import PanelLengthMode
+from FixedSizeBin import FixedSizeBin
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gio", "2.0")
@@ -30,10 +31,13 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.settings.connect("changed", self.settings_changed)
 
         self.box: Gtk.Box = Gtk.Box(spacing=10)
-        if self.settings.get_uint("panel-length-mode") == PanelLengthMode.Fixed:
-            # TODO: this code is also repeated at line 233 -> possibly make a func
-            self._set_box_size_request()
         self.add(self.box)
+
+        self.panel_view_size_bin: FixedSizeBin = FixedSizeBin(
+            size=self.settings.get_uint("panel-length-fixed"),
+            orientation=self.orientation,
+        )
+        self.box.pack_start(self.panel_view_size_bin, False, False, 0)
 
         self.popup_icon: Gtk.Image = Gtk.Image.new_from_icon_name(
             "budgie-media-player-applet-arrow-drop-down-symbolic", Gtk.IconSize.MENU
@@ -170,28 +174,19 @@ class BudgieMediaPlayer(Budgie.Applet):
 
         if changed_key_name in {"panel-length-mode", "panel-length-fixed"}:
             if self.settings.get_uint("panel-length-mode") == PanelLengthMode.Fixed:
-                self._set_box_size_request()
+                self.panel_view_size_bin.set_size(
+                    self.settings.get_uint("panel-length-fixed")
+                )
             else:
-                self.box.set_size_request(-1, -1)
+                self.panel_view_size_bin.set_size(None)
             return
-
-    def _set_box_size_request(self) -> None:
-        if self.orientation == Gtk.Orientation.HORIZONTAL:
-            self.box.set_size_request(
-                width=self.settings.get_uint("panel-length-fixed"),
-                height=-1,
-            )
-        else:
-            self.box.set_size_request(
-                width=-1,
-                height=self.settings.get_uint("panel-length-fixed"),
-            )
 
     def _add_panel_view(self, player: PopupPlasmaControlView) -> None:
         player.add_panel_view(
             orientation=self.orientation,
         )
-        self.box.pack_start(player.panel_view, True, True, 0)
+        # self.box.pack_start(player.panel_view, True, True, 0)
+        self.panel_view_size_bin.add(player.panel_view)
         self.panel_player_service_name = player.service_name
 
     def _add_popup_plasma_control_view(self, service_name: str) -> None:
@@ -231,8 +226,7 @@ class BudgieMediaPlayer(Budgie.Applet):
             player.panel_orientation_changed(self.orientation)
 
         if self.settings.get_uint("panel-length-mode") == PanelLengthMode.Fixed:
-            # TODO: it's repeated here
-            self._set_box_size_request()
+            self.panel_view_size_bin.set_orientation(self.orientation)
 
     def do_get_settings_ui(self):
         """Return the applet settings with given uuid"""

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -5,7 +5,7 @@ from typing import Optional
 import gi
 from SettingsPage import SettingsPage
 from PopupPlasmaControlView import PopupPlasmaControlView
-from EnumsStructs import PanelLengthType
+from EnumsStructs import PanelLengthMode
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gio", "2.0")
@@ -30,7 +30,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.settings.connect("changed", self.settings_changed)
 
         self.box: Gtk.Box = Gtk.Box(spacing=10)
-        if self.settings.get_uint("panel-length-type") == PanelLengthType.Fixed:
+        if self.settings.get_uint("panel-length-mode") == PanelLengthMode.Fixed:
             # TODO: this code is also repeated at line 233 -> possibly make a func
             self._set_box_size_request()
         self.add(self.box)
@@ -168,8 +168,8 @@ class BudgieMediaPlayer(Budgie.Applet):
             )
             return
 
-        if changed_key_name in {"panel-length-type", "panel-max-length"}:
-            if self.settings.get_uint("panel-length-type") == PanelLengthType.Fixed:
+        if changed_key_name in {"panel-length-mode", "panel-length-fixed"}:
+            if self.settings.get_uint("panel-length-mode") == PanelLengthMode.Fixed:
                 self._set_box_size_request()
             else:
                 self.box.set_size_request(-1, -1)
@@ -178,20 +178,20 @@ class BudgieMediaPlayer(Budgie.Applet):
     def _set_box_size_request(self) -> None:
         if self.orientation == Gtk.Orientation.HORIZONTAL:
             self.box.set_size_request(
-                width=self.settings.get_uint("panel-max-length"),
+                width=self.settings.get_uint("panel-length-fixed"),
                 height=-1,
             )
         else:
             self.box.set_size_request(
                 width=-1,
-                height=self.settings.get_uint("panel-max-length"),
+                height=self.settings.get_uint("panel-length-fixed"),
             )
 
     def _add_panel_view(self, player: PopupPlasmaControlView) -> None:
         player.add_panel_view(
             orientation=self.orientation,
         )
-        self.box.pack_start(player.panel_view, False, False, 0)
+        self.box.pack_start(player.panel_view, True, True, 0)
         self.panel_player_service_name = player.service_name
 
     def _add_popup_plasma_control_view(self, service_name: str) -> None:
@@ -230,7 +230,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         ) is not None:
             player.panel_orientation_changed(self.orientation)
 
-        if self.settings.get_uint("panel-length-type") == PanelLengthType.Fixed:
+        if self.settings.get_uint("panel-length-mode") == PanelLengthMode.Fixed:
             # TODO: it's repeated here
             self._set_box_size_request()
 

--- a/src/EnumsStructs.py
+++ b/src/EnumsStructs.py
@@ -10,6 +10,12 @@ gi.require_version("Gio", "2.0")
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gio, GdkPixbuf
 
+"""
+This file is for enums and dataclasses (structs) 
+that are accessed from multiple files and having 
+them there would result in circular dependencies
+"""
+
 
 class AlbumCoverType(IntEnum):
     Null = 0
@@ -24,3 +30,10 @@ class AlbumCoverData:
     image_url_http: Optional[str]
     song_cover_pixbuf: Optional[GdkPixbuf.Pixbuf]
     song_cover_other: Union[Gio.Icon, str, None]
+
+
+# TODO: come up with better names
+class PanelLengthType(IntEnum):
+    NoLimit = 0
+    Variable = 1
+    Fixed = 2

--- a/src/EnumsStructs.py
+++ b/src/EnumsStructs.py
@@ -32,8 +32,7 @@ class AlbumCoverData:
     song_cover_other: Union[Gio.Icon, str, None]
 
 
-# TODO: come up with better names
-class PanelLengthType(IntEnum):
+class PanelLengthMode(IntEnum):
     NoLimit = 0
     Variable = 1
     Fixed = 2

--- a/src/FixedSizeBin.py
+++ b/src/FixedSizeBin.py
@@ -1,0 +1,91 @@
+# Copyright 2024, zalesyc and the budgie-media-player-applet contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import gi
+from typing import Optional
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gtk, Gdk
+
+
+class FixedSizeBin(Gtk.Bin):
+    """
+    A single-child container that has fixed size (width or height) based on orientation.
+    """
+
+    def __init__(
+        self,
+        size: Optional[int] = None,
+        orientation: Gtk.Orientation = Gtk.Orientation.HORIZONTAL,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.preferred_size: Optional[int] = size
+        self.orientation: Gtk.Orientation = orientation
+
+    def set_size(self, new_size: Optional[int]) -> None:
+        self.preferred_size = new_size
+        self.queue_resize()
+
+    def set_orientation(self, new_orientation: Gtk.Orientation) -> None:
+        self.orientation = new_orientation
+        self.queue_resize()
+
+    def do_size_allocate(self, allocation: Gdk.Rectangle) -> None:
+        if self.get_child() is None:
+            return
+        if self.preferred_size is None:
+            self.get_child().size_allocate(allocation)
+            return
+        child_allocation = Gdk.Rectangle()
+        child_allocation.x = allocation.x
+        child_allocation.y = allocation.y
+        if self.orientation == Gtk.Orientation.HORIZONTAL:
+            child_min_width, _ = self.get_child().get_preferred_width()
+            child_allocation.height = allocation.height
+            child_allocation.width = min(
+                max(child_min_width, self.preferred_size),
+                allocation.width,
+            )
+        else:
+            child_min_height, _ = self.get_child().get_preferred_height()
+            child_allocation.width = allocation.width
+            child_allocation.height = min(
+                max(child_min_height, self.preferred_size),
+                allocation.height,
+            )
+
+        self.get_child().size_allocate(child_allocation)
+
+    def do_get_preferred_width(self) -> tuple[int, int]:
+        if self.get_child() is None:
+            return 0, 0
+
+        if self.preferred_size is None:
+            return self.get_child().get_preferred_width()
+
+        if self.orientation == Gtk.Orientation.HORIZONTAL:
+            child_min_width, _ = self.get_child().get_preferred_width()
+            return child_min_width, max(child_min_width, self.preferred_size)
+        else:
+            return self.get_child().get_preferred_width()
+
+    def do_get_preferred_height(self):
+        if self.get_child() is None:
+            return 0, 0
+
+        if self.preferred_size is None:
+            return self.get_child().get_preferred_height()
+
+        if self.orientation == Gtk.Orientation.HORIZONTAL:
+            return self.get_child().get_preferred_height()
+        else:
+            child_min_height, _ = self.get_child().get_preferred_height()
+            return child_min_height, max(child_min_height, self.preferred_size)
+
+    def do_get_preferred_height_for_width(self, _) -> tuple[int, int]:
+        return self.do_get_preferred_height()
+
+    def do_get_preferred_width_for_height(self, _) -> tuple[int, int]:
+        return self.do_get_preferred_width()

--- a/src/Labels.py
+++ b/src/Labels.py
@@ -239,9 +239,10 @@ class ElliptedLabel(Gtk.Label):
 class LabelWSubtitle(Gtk.Box):
     """
     A label with a title and a subtitle.
+    For wrap_subtitle the label has to be set to fill its parent layout
     """
 
-    def __init__(self, title: str, subtitle: str, **kwargs):
+    def __init__(self, title: str, subtitle: str, wrap_subtitle=False, **kwargs):
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, **kwargs)
         title_label = Gtk.Label(
             label=title,
@@ -251,7 +252,10 @@ class LabelWSubtitle(Gtk.Box):
         subtitle_label = Gtk.Label(
             label=f'<span size="smaller" weight="light">{markup_escape_text(subtitle)}</span>',
             use_markup=True,
-            halign=Gtk.Align.START,
+            halign=Gtk.Align.FILL if wrap_subtitle else Gtk.Align.START,
+            max_width_chars=1 if wrap_subtitle else -1,
+            wrap=wrap_subtitle,
+            xalign=0.0,
         )
         self.pack_start(title_label, False, True, 0)
         self.pack_start(subtitle_label, False, True, 0)

--- a/src/PanelControlView.py
+++ b/src/PanelControlView.py
@@ -19,7 +19,6 @@ from gi.repository.Pango import EllipsizeMode
 class Element:
     widget: Gtk.Widget
     spacing: int = 0
-    expand: bool = False
 
 
 class PanelControlView(Gtk.Box):
@@ -67,21 +66,17 @@ class PanelControlView(Gtk.Box):
             self.set_album_cover(album_cover)
 
         # song_name
-        self.song_name_label.set_xalign(0.0)
         song_name_event_box = Gtk.EventBox()
         song_name_event_box.add(self.song_name_label)
         song_name_event_box.connect("button-press-event", self._song_clicked)
-        self.available_elements.update(
-            {"song_name": Element(song_name_event_box, 4, expand=True)}
-        )
+        self.available_elements.update({"song_name": Element(song_name_event_box, 4)})
 
         # song_author
-        self.song_name_label.set_xalign(0.0)
         song_author_event_box = Gtk.EventBox()
         song_author_event_box.add(self.song_author_label)
         song_author_event_box.connect("button-press-event", self._song_clicked)
         self.available_elements.update(
-            {"song_author": Element(song_author_event_box, 4, expand=True)}
+            {"song_author": Element(song_author_event_box, 4)}
         )
 
         # song_separator
@@ -251,9 +246,7 @@ class PanelControlView(Gtk.Box):
                     "not in available elements - probably wrong settings -> skipping"
                 )
                 continue
-            self.pack_start(
-                element.widget, element.expand, element.expand, element.spacing
-            )
+            self.pack_start(element.widget, False, False, element.spacing)
 
         self.show_all()
 
@@ -311,9 +304,6 @@ class PanelControlView(Gtk.Box):
             self.song_author_label.set_max_width_chars(
                 max(-1, self.settings.get_int("author-name-max-length"))
             )
-        elif panel_len_mode == PanelLengthMode.Fixed:
-            self.song_name_label.set_max_width_chars(1)
-            self.song_author_label.set_max_width_chars(1)
         else:
             self.song_name_label.set_max_width_chars(-1)
             self.song_author_label.set_max_width_chars(-1)

--- a/src/PanelControlView.py
+++ b/src/PanelControlView.py
@@ -1,7 +1,7 @@
 # Copyright 2024, zalesyc and the budgie-media-player-applet contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from AlbumCoverData import AlbumCoverType, AlbumCoverData
+from EnumsStructs import AlbumCoverType, AlbumCoverData, PanelLengthType
 from mprisWrapper import MprisWrapper
 from dataclasses import dataclass
 from typing import Optional, Callable
@@ -70,7 +70,6 @@ class PanelControlView(Gtk.Box):
         self.song_name_label.set_max_width_chars(
             max(-1, settings.get_int("author-name-max-length"))
         )
-        self.song_name_label.set_max_width_chars(10)
         song_name_event_box = Gtk.EventBox()
         song_name_event_box.add(self.song_name_label)
         song_name_event_box.connect("button-press-event", self._song_clicked)
@@ -289,9 +288,24 @@ class PanelControlView(Gtk.Box):
     def _settings_changed(self, settings: Gio.Settings, key: str) -> None:
         if key == "separator-text":
             self.song_separator.set_label(settings.get_string(key))
-        elif key == "author-name-max-length":
-            self.song_name_label.set_max_width_chars(max(-1, settings.get_int(key)))
-        elif key == "media-title-max-length":
-            self.song_author_label.set_max_width_chars(max(-1, settings.get_int(key)))
         elif key == "element-order":
             self._set_element_order(settings.get_strv(key))
+        elif key in {
+            "panel-length-type",
+            "media-title-max-length",
+            "author-name-max-length",
+        }:
+            if settings.get_uint("panel-length-type") == PanelLengthType.Variable:
+                self.song_name_label.set_ellipsize(EllipsizeMode.END)
+                self.song_author_label.set_ellipsize(EllipsizeMode.END)
+                self.song_name_label.set_max_width_chars(
+                    max(-1, settings.get_int("media-title-max-length"))
+                )
+                self.song_author_label.set_max_width_chars(
+                    max(-1, settings.get_int("author-name-max-length"))
+                )
+            else:
+                self.song_name_label.set_max_width_chars(-1)
+                self.song_author_label.set_max_width_chars(-1)
+                self.song_name_label.set_ellipsize(EllipsizeMode.NONE)
+                self.song_author_label.set_ellipsize(EllipsizeMode.NONE)

--- a/src/PopupPlasmaControlView.py
+++ b/src/PopupPlasmaControlView.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from SingleAppPlayer import SingleAppPlayer
-from AlbumCoverData import AlbumCoverType
+from EnumsStructs import AlbumCoverType
 from Labels import ScrollingLabel, ElliptedLabel
 from typing import Callable, Optional, Union
 from enum import IntEnum

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -8,7 +8,7 @@ gi.require_version("Gio", "2.0")
 from gi.repository import Gtk, Gio
 
 from Labels import LabelWSubtitle
-from EnumsStructs import PanelLengthType
+from EnumsStructs import PanelLengthMode
 from math import ceil
 from typing import Union
 
@@ -90,8 +90,8 @@ class PanelSettingsPage(_SettingsPageBase):
             },
             hexpand=True,
         )
-        max_len_type: PanelLengthType = PanelLengthType(
-            settings.get_uint("panel-length-type")
+        max_len_type: PanelLengthMode = PanelLengthMode(
+            settings.get_uint("panel-length-mode")
         )
         max_len_title = LabelWSubtitle(
             title="Length:",
@@ -100,7 +100,7 @@ class PanelSettingsPage(_SettingsPageBase):
         )
 
         max_len_no_limit_radio = Gtk.RadioButton(
-            active=max_len_type == PanelLengthType.NoLimit,
+            active=max_len_type == PanelLengthMode.NoLimit,
         )
         max_len_no_limit_radio.connect(
             "toggled",
@@ -116,7 +116,7 @@ class PanelSettingsPage(_SettingsPageBase):
 
         max_len_fixed_radio = Gtk.RadioButton(
             group=max_len_no_limit_radio,
-            active=max_len_type == PanelLengthType.Fixed,
+            active=max_len_type == PanelLengthMode.Fixed,
         )
         max_len_fixed_label = LabelWSubtitle(
             title="Fixed",
@@ -133,13 +133,15 @@ class PanelSettingsPage(_SettingsPageBase):
         max_len_fixed_value_scale = Gtk.Scale.new_with_range(
             Gtk.Orientation.HORIZONTAL, 10, 1000, 1
         )
-        max_len_fixed_value_scale.set_sensitive(max_len_type == PanelLengthType.Fixed)
+        max_len_fixed_value_scale.set_sensitive(max_len_type == PanelLengthMode.Fixed)
         max_len_fixed_value_scale.set_value_pos(Gtk.PositionType.LEFT)
-        max_len_fixed_value_scale.set_value(self.settings.get_uint("panel-max-length"))
+        max_len_fixed_value_scale.set_value(
+            self.settings.get_uint("panel-length-fixed")
+        )
         max_len_fixed_value_scale.connect(
             "value-changed",
             lambda scale: self.settings.set_uint(
-                "panel-max-length", round(scale.get_value())
+                "panel-length-fixed", round(scale.get_value())
             ),
         )
         max_len_fixed_radio.connect(
@@ -150,7 +152,7 @@ class PanelSettingsPage(_SettingsPageBase):
 
         max_len_variable_radio = Gtk.RadioButton(
             group=max_len_no_limit_radio,
-            active=max_len_type == PanelLengthType.Variable,
+            active=max_len_type == PanelLengthMode.Variable,
         )
         max_len_variable_label = LabelWSubtitle(
             title="Maximal Length",
@@ -175,7 +177,7 @@ class PanelSettingsPage(_SettingsPageBase):
         max_len_variable_value_name = self.settings.get_int("media-title-max-length")
         self.max_len_variable_value_name_check = Gtk.CheckButton(
             active=max_len_variable_value_name >= 0,
-            sensitive=max_len_type == PanelLengthType.Variable,
+            sensitive=max_len_type == PanelLengthMode.Variable,
         )
         self.max_len_variable_value_name_spin = Gtk.SpinButton.new_with_range(
             min=5,
@@ -187,7 +189,7 @@ class PanelSettingsPage(_SettingsPageBase):
         )
         self.max_len_variable_value_name_spin.set_sensitive(
             max_len_variable_value_name >= 0
-            and max_len_type == PanelLengthType.Variable
+            and max_len_type == PanelLengthMode.Variable
         )
         max_len_variable_value_name_box.pack_start(
             self.max_len_variable_value_name_check, False, False, 15
@@ -223,7 +225,7 @@ class PanelSettingsPage(_SettingsPageBase):
         max_len_variable_value_author = self.settings.get_int("author-name-max-length")
         self.max_len_variable_value_author_check = Gtk.CheckButton(
             active=max_len_variable_value_author >= 0,
-            sensitive=max_len_type == PanelLengthType.Variable,
+            sensitive=max_len_type == PanelLengthMode.Variable,
         )
         self.max_len_variable_value_author_spin = Gtk.SpinButton.new_with_range(
             min=5,
@@ -241,7 +243,7 @@ class PanelSettingsPage(_SettingsPageBase):
         )
         self.max_len_variable_value_author_spin.set_sensitive(
             max_len_variable_value_author >= 0
-            and max_len_type == PanelLengthType.Variable
+            and max_len_type == PanelLengthMode.Variable
         )
         self.max_len_variable_value_author_check.connect(
             "toggled",
@@ -326,7 +328,7 @@ class PanelSettingsPage(_SettingsPageBase):
         radio: Gtk.ToggleButton,
     ):
         if radio.get_active():
-            self.settings.set_uint("panel-length-type", PanelLengthType.NoLimit)
+            self.settings.set_uint("panel-length-mode", PanelLengthMode.NoLimit)
 
     def _fixed_len_radio_toggled(
         self,
@@ -338,7 +340,7 @@ class PanelSettingsPage(_SettingsPageBase):
             widget.set_sensitive(active)
 
         if active:
-            self.settings.set_uint("panel-length-type", PanelLengthType.Fixed)
+            self.settings.set_uint("panel-length-mode", PanelLengthMode.Fixed)
 
     def _variable_len_radio_toggled(
         self,
@@ -356,7 +358,7 @@ class PanelSettingsPage(_SettingsPageBase):
             self.max_len_variable_value_author_spin.set_sensitive(active)
 
         if active:
-            self.settings.set_uint("panel-length-type", PanelLengthType.Variable)
+            self.settings.set_uint("panel-length-mode", PanelLengthMode.Variable)
 
 
 class PopoverSettingsPage(_SettingsPageBase):

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse, ParseResult
 import requests
 from PIL import Image
 from PanelControlView import PanelControlView
-from AlbumCoverData import AlbumCoverType, AlbumCoverData
+from EnumsStructs import AlbumCoverType, AlbumCoverData
 from mprisWrapper import MprisWrapper
 
 import gi

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,7 +4,7 @@ install_data(
     'PanelControlView.py',
     'BudgieMediaPlayer.py',
     'PopupPlasmaControlView.py',
-    'AlbumCoverData.py',
+    'EnumsStructs.py',
     'mprisWrapper.py',
     'SettingsPage.py',
     'Labels.py',

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,5 +8,6 @@ install_data(
     'mprisWrapper.py',
     'SettingsPage.py',
     'Labels.py',
+    'FixedSizeBin.py',
     install_dir: PLUGINS_INSTALL_DIR
 )


### PR DESCRIPTION
### Changes:
Create 2 new modes for how the applet in the panel is sized
Modes:
- No limit
- Fixed length: the applet will always be this long
- Maximal length: the old behavior, there is max length for the author label and the name label **default**

#### Technical: 
- There is new file FixedSizeBin.py that contains a Gtk.Bin subclass that
can set a fixed size to its child, this is used for the fixed size mode.
- There are also two new settings: `panel-length-mode` and `panel-length-fixed`.

### Reason:
I feel like the fixed length mode is useful, because other applets in the panel don't jump around when the playing song/video changes. The no limit mode was added because I felt like it made sense to include it, even if I don't think it is good idea to use it.