### PR TITLE
Better popover handling

### DIFF
--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -50,9 +50,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         self.box.pack_end(self.popup_icon_event_box, False, False, 0)
 
         self.popover: Popover = Popover(relative_to=self, settings=self.settings)
-
-        self.popover_manager: Budgie.PopoverManager = Budgie.PopoverManager()
-        self.popover_manager.register_popover(self, self.popover)
+        self.popover_manager: Optional[Budgie.PopoverManager] = None
 
         self.session_bus: Gio.DBusConnection = Gio.bus_get_sync(
             Gio.BusType.SESSION, None
@@ -81,7 +79,8 @@ class BudgieMediaPlayer(Budgie.Applet):
             self.popup_icon.hide()
 
     def show_popup(self, *_) -> None:
-        self.popover_manager.show_popover(self)
+        if self.popover_manager is not None:
+            self.popover_manager.show_popover(self)
 
     def favorite_player_clicked(self, service_name: str) -> None:
         if len(self.players_list) <= 1:
@@ -211,3 +210,7 @@ class BudgieMediaPlayer(Budgie.Applet):
         """Return True if support setting through Budgie Setting,
         False otherwise."""
         return True
+
+    def do_update_popovers(self, manager: Budgie.PopoverManager) -> None:
+        self.popover_manager = manager
+        self.popover_manager.register_popover(self, self.popover)

--- a/src/Popover.py
+++ b/src/Popover.py
@@ -12,10 +12,6 @@ from gi.repository import Gtk, Gio, Budgie
 
 
 class Popover(Budgie.Popover):
-    """
-    Budgie.Popover inherits from Gtk.Popover
-    """
-
     def __init__(self, relative_to: Gtk.Widget, settings: Gio.Settings):
         super().__init__(relative_to=relative_to)
         self._nothing_is_playing_label: Optional[Gtk.Widget] = None

--- a/src/Popover.py
+++ b/src/Popover.py
@@ -1,0 +1,83 @@
+# Copyright 2024, zalesyc and the budgie-media-player-applet contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import gi
+from typing import Optional
+from SingleAppPlayer import SingleAppPlayer
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gio", "2.0")
+gi.require_version("Budgie", "1.0")
+from gi.repository import Gtk, Gio, Budgie
+
+
+class Popover(Budgie.Popover):
+    """
+    Budgie.Popover inherits from Gtk.Popover
+    """
+
+    def __init__(self, relative_to: Gtk.Widget, settings: Gio.Settings):
+        super().__init__(relative_to=relative_to)
+        self._nothing_is_playing_label: Optional[Gtk.Widget] = None
+
+        self.connect("closed", self._on_closed)
+        self.connect("show", self._on_showed)
+        self.set_size_request(
+            width=settings.get_uint("popover-width"),
+            height=settings.get_uint("popover-height"),
+        )
+        settings.connect("changed", self._settings_changed)
+
+        self._players_ntb = Gtk.Notebook(
+            margin_start=5,
+            margin_end=5,
+            margin_bottom=5,
+            show_border=False,
+            scrollable=True,
+        )
+        self._players_ntb.connect("page-removed", self._on_page_removed)
+        self._players_ntb.connect("page-added", self._on_page_added)
+        self.add(self._players_ntb)
+        self._on_page_removed()
+
+    def add_player(self, player: SingleAppPlayer) -> None:
+        self._players_ntb.append_page(child=player, tab_label=player.icon)
+        self._players_ntb.show_all()
+
+    def _on_showed(self, _) -> None:
+        self._players_ntb.foreach(lambda player: player.popover_to_be_open())
+
+    def _on_closed(self, _) -> None:
+        self._players_ntb.foreach(lambda player: player.popover_just_closed())
+
+    def _settings_changed(self, settings: Gio.Settings, changed_key: str) -> None:
+        if changed_key in {"popover-width", "popover-height"}:
+            self.set_size_request(
+                width=settings.get_uint("popover-width"),
+                height=settings.get_uint("popover-height"),
+            )
+            return
+
+    def _on_page_removed(self, *_) -> None:
+        if self._players_ntb.get_n_pages() < 1:
+            self._nothing_is_playing_label = Gtk.Label(
+                label='<span size="large" weight="bold">There is nothing playing</span>',
+                use_markup=True,
+                wrap=True,
+                max_width_chars=1,
+                hexpand=True,
+                vexpand=True,
+            )
+            self._players_ntb.append_page(
+                self._nothing_is_playing_label,
+                Gtk.Label(label=""),
+            )
+            self._nothing_is_playing_label.show_all()
+
+    def _on_page_added(self, *_) -> None:
+        if (
+            self._players_ntb.get_n_pages() > 1
+            and self._nothing_is_playing_label is not None
+        ):
+            self._nothing_is_playing_label.destroy()
+            self._nothing_is_playing_label = None

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,5 +9,6 @@ install_data(
     'SettingsPage.py',
     'Labels.py',
     'FixedSizeBin.py',
+    'Popover.py',
     install_dir: PLUGINS_INSTALL_DIR
 )

--- a/src/testWin.py
+++ b/src/testWin.py
@@ -25,6 +25,8 @@ class MyWindow(Gtk.Window):
             if sys.argv[1] == "-v":
                 self.player.do_panel_position_changed(Budgie.PanelPosition.LEFT)
         self.add(self.player)
+        popover_mgr = Budgie.PopoverManager()
+        self.player.do_update_popovers(popover_mgr)
 
 
 def main():


### PR DESCRIPTION
### Changes:
1. Moved the handling of the popover and the `Gtk.Notebook` that contains the players in the popover into a new class called `Popover` in a new file named `Popover.py`. 
2. Added a note to the popover when nothing is playing. 
3. Updated the applet to use the correct `Budgie.PopoverManager` provided by Budgie, supposedly allowing activation when the parent widget is rolled over or when another widget is visible.