### PR TITLE
 Change the way the album image is processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,22 @@ see: [Nixos Packages](https://search.nixos.org/packages?show=budgiePlugins.budgi
 #### 1. Install dependencies
 Ubuntu, Debian:
 ~~~ shell
-sudo apt install git meson ninja-build python3-requests python3-gi python3-pil libglib2.0-bin
+sudo apt install git meson ninja-build python3-requests python3-gi libglib2.0-bin
 ~~~
 
 Fedora:
 ~~~ shell
-sudo dnf install git meson ninja-build python3-pillow python3-requests python3-gobject
+sudo dnf install git meson ninja-build python3-requests python3-gobject
 ~~~
 
 Arch Linux:
 ~~~ shell
-sudo pacman -S git meson ninja python-requests python-pillow
+sudo pacman -S git meson ninja python-requests
 ~~~
 
 openSUSE:
 ~~~ shell
-sudo zypper in git-core ninja meson glib2-tools python3-Pillow python3-requests python3-gobject python3-gobject-Gdk
+sudo zypper in git-core ninja meson glib2-tools python3-requests python3-gobject python3-gobject-Gdk
 ~~~
 
 <details>

--- a/src/SingleAppPlayer.py
+++ b/src/SingleAppPlayer.py
@@ -3,11 +3,9 @@
 
 import threading
 from typing import Optional, Union, Callable
-from io import BytesIO
 from dataclasses import dataclass
 from urllib.parse import urlparse, ParseResult
 import requests
-from PIL import Image
 from PanelControlView import PanelControlView
 from EnumsStructs import AlbumCoverType, AlbumCoverData
 from mprisWrapper import MprisWrapper


### PR DESCRIPTION
PIL is no longer used for the processing,  more: bfc6dbb49ab96dab11e3770cc9a085cf89d1c3a2

**Removed PIL (python3-pil / python3-pillow) as a dependency**