### PR TITLE
Add a label shown when there is nothing playing

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -37,6 +37,16 @@
             <description>Whether to show the arrow, which opens the popover.</description>
             <default>false</default>
         </key>
+        <key type="b" name="panel-show-nothing-playing">
+            <summary>Whether to show a note when there is nothing playing </summary>
+            <description>There is being shown the default icon and the text in panel-nothing-playing-text.</description>
+            <default>true</default>
+        </key>
+        <key type="s" name="panel-nothing-playing-text">
+            <summary>The text used in the panel when there is nothing playing</summary>
+            <description>The text is shown only when panel-show-nothing-playing is true.</description>
+            <default>"There is nothing playing"</default>
+        </key>
         <key type="u" name="popover-width">
             <summary>The width of the popover</summary>
             <description>The width of the popover in px.</description>

--- a/src/Popover.py
+++ b/src/Popover.py
@@ -41,10 +41,12 @@ class Popover(Budgie.Popover):
         self._players_ntb.show_all()
 
     def _on_showed(self, _) -> None:
-        self._players_ntb.foreach(lambda player: player.popover_to_be_open())
+        if self._nothing_is_playing_label is None:
+            self._players_ntb.foreach(lambda player: player.popover_to_be_open())
 
     def _on_closed(self, _) -> None:
-        self._players_ntb.foreach(lambda player: player.popover_just_closed())
+        if self._nothing_is_playing_label is None:
+            self._players_ntb.foreach(lambda player: player.popover_just_closed())
 
     def _settings_changed(self, settings: Gio.Settings, changed_key: str) -> None:
         if changed_key in {"popover-width", "popover-height"}:
@@ -57,7 +59,7 @@ class Popover(Budgie.Popover):
     def _on_page_removed(self, *_) -> None:
         if self._players_ntb.get_n_pages() < 1:
             self._nothing_is_playing_label = Gtk.Label(
-                label='<span size="large" weight="bold">There is nothing playing</span>',
+                label='<span weight="bold">No apps are currently playing audio</span>',
                 use_markup=True,
                 wrap=True,
                 max_width_chars=1,
@@ -68,7 +70,7 @@ class Popover(Budgie.Popover):
                 self._nothing_is_playing_label,
                 Gtk.Label(label=""),
             )
-            self._nothing_is_playing_label.show_all()
+            self._players_ntb.show_all()
 
     def _on_page_added(self, *_) -> None:
         if (

--- a/src/SettingsPage.py
+++ b/src/SettingsPage.py
@@ -296,6 +296,41 @@ class PanelSettingsPage(_SettingsPageBase):
         )
         show_arrow_switch.connect("state_set", self.show_arrow_changed)
 
+        show_nothing_playing_label = LabelWSubtitle(
+            title="Show ‘Nothing Playing’ Label:",
+            subtitle="Whether to show a label with the text specified below, "
+            "that is shown when there is nothing playing.",
+            wrap_subtitle=True,
+        )
+        show_nothing_playing_enabled = self.settings.get_boolean(
+            "panel-show-nothing-playing"
+        )
+        show_nothing_playing_switch = Gtk.Switch(
+            halign=Gtk.Align.START,
+            valign=Gtk.Align.CENTER,
+            active=show_nothing_playing_enabled,
+        )
+
+        show_nothing_playing_text_label = Gtk.Label(
+            label="Text:",
+            halign=Gtk.Align.START,
+            margin_left=30,
+        )
+        self.show_nothing_playing_text_entry = Gtk.Entry(
+            text=settings.get_string("panel-nothing-playing-text"),
+            sensitive=show_nothing_playing_enabled,
+        )
+        self.show_nothing_playing_text_entry.connect(
+            "changed",
+            lambda _: self.settings.set_string(
+                "panel-nothing-playing-text",
+                self.show_nothing_playing_text_entry.get_text(),
+            ),
+        )
+        show_nothing_playing_switch.connect(
+            "state-set", self._show_nothing_playing_switch_changed
+        )
+
         self.attach(order_label, 0, 0, 2, 1)
         self.attach(order_widget, 0, 1, 2, 1)
 
@@ -319,8 +354,20 @@ class PanelSettingsPage(_SettingsPageBase):
         self.attach(show_arrow_label, 0, 12, 1, 1)
         self.attach(show_arrow_switch, 1, 12, 1, 1)
 
+        self.attach(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL), 0, 13, 2, 1)
+
+        self.attach(show_nothing_playing_label, 0, 14, 1, 1)
+        self.attach(show_nothing_playing_switch, 1, 14, 1, 1)
+        self.attach(show_nothing_playing_text_label, 0, 15, 1, 1)
+        self.attach(self.show_nothing_playing_text_entry, 1, 15, 1, 1)
+
     def show_arrow_changed(self, _, new_state: bool) -> bool:
         self.settings.set_boolean("show-arrow", new_state)
+        return False
+
+    def _show_nothing_playing_switch_changed(self, _, new_state: bool) -> bool:
+        self.settings.set_boolean("panel-show-nothing-playing", new_state)
+        self.show_nothing_playing_text_entry.set_sensitive(new_state)
         return False
 
     def _no_limit_len_radio_toggled(


### PR DESCRIPTION
This new feature can be turned off in the settings, but is on by default, you can also customize the text that is being shown.