### PR TITLE
Click actions

### DIFF
--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -47,6 +47,12 @@
             <description>The text is shown only when panel-show-nothing-playing is true.</description>
             <default>"There is nothing playing"</default>
         </key>
+        <key type="a{uu}" name="panel-click-action">
+            <summary>Action caused by clicking on the panel with different mouse buttons</summary>
+            <description>What action is caused by clicking on the panel part of the applet. The dictonary key is the mouse button determined by gtk, usually: (1: left; 2: middle; 3: right; ...), the dictonary value is the action to cause: (0: open popover; 1: play/pause, 2: next; 3: previous)</description>
+            <default>[{1,0}, {2,1}, {3,0}]</default>
+        </key>
+
         <key type="u" name="popover-width">
             <summary>The width of the popover</summary>
             <description>The width of the popover in px.</description>

--- a/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
+++ b/schema/com.github.zalesyc.budgie-media-player-applet.gschema.xml
@@ -49,7 +49,7 @@
         </key>
         <key type="a{uu}" name="panel-click-action">
             <summary>Action caused by clicking on the panel with different mouse buttons</summary>
-            <description>What action is caused by clicking on the panel part of the applet. The dictonary key is the mouse button determined by gtk, usually: (1: left; 2: middle; 3: right; ...), the dictonary value is the action to cause: (0: open popover; 1: play/pause, 2: next; 3: previous)</description>
+            <description>What action is caused by clicking on the panel part of the applet. The dictionary key is the mouse button determined by gtk, usually: (1: left; 2: middle; 3: right; ...), the dictionary value is the action to cause: (0: open popover; 1: play/pause, 2: next; 3: previous)</description>
             <default>[{1,0}, {2,1}, {3,0}]</default>
         </key>
 

--- a/src/EnumsStructs.py
+++ b/src/EnumsStructs.py
@@ -36,3 +36,10 @@ class PanelLengthMode(IntEnum):
     NoLimit = 0
     Variable = 1
     Fixed = 2
+
+
+class PanelClickAction(IntEnum):
+    open_popover: int = 0
+    play_pause: int = 1
+    next: int = 2
+    previous: int = 3

--- a/src/PanelControlView.py
+++ b/src/PanelControlView.py
@@ -1,11 +1,15 @@
 # Copyright 2024, zalesyc and the budgie-media-player-applet contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from EnumsStructs import AlbumCoverType, AlbumCoverData, PanelLengthMode
+from EnumsStructs import (
+    AlbumCoverType,
+    AlbumCoverData,
+    PanelLengthMode,
+    PanelClickAction,
+)
 from mprisWrapper import MprisWrapper
 from dataclasses import dataclass
 from typing import Optional, Callable
-from enum import IntEnum
 import gi
 
 gi.require_version("Gtk", "3.0")
@@ -22,13 +26,6 @@ from gi.repository.Gdk import EventButton
 class Element:
     widget: Gtk.Widget
     spacing: int = 0
-
-
-class ClickAction(IntEnum):
-    open_popover: int = 0
-    play_pause: int = 1
-    next: int = 2
-    previous: int = 3
 
 
 class PanelControlView(Gtk.Box):
@@ -56,7 +53,7 @@ class PanelControlView(Gtk.Box):
         self.separator_text: str = ""
         self.available_elements: dict[str, Element] = {}
         self.element_order: list[str] = []
-        self.click_actions: dict[int, ClickAction] = {}
+        self.click_actions: dict[int, PanelClickAction] = {}
 
         self.album_cover: Gtk.Image = Gtk.Image.new_from_icon_name(
             "emblem-music-symbolic", Gtk.IconSize.MENU
@@ -256,12 +253,12 @@ class PanelControlView(Gtk.Box):
         self.dbus_player.call_player_method("Previous")
 
     def _song_clicked(self, _, event: EventButton) -> None:
-        action = self.click_actions.get(event.button, ClickAction.open_popover)
-        if action == ClickAction.next:
+        action = self.click_actions.get(event.button, PanelClickAction.open_popover)
+        if action == PanelClickAction.next:
             self._forward_clicked()
-        elif action == ClickAction.previous:
+        elif action == PanelClickAction.previous:
             self._backward_clicked()
-        elif action == ClickAction.play_pause:
+        elif action == PanelClickAction.play_pause:
             self._play_paused_clicked()
         else:
             self.open_popover_func()


### PR DESCRIPTION
# Click actions
**Implemented customizable actions for left, middle, and right mouse clicks on the applet.**

This is useful for quickly performing actions like play/pause (I use middle-click daily) without opening the popup.

### Default:
- **Left-click:** Opens the applet popup.
- **Middle-click:** Toggles play/pause.
- **Right-click:** Opens the applet popup.

### Limitations:
- The three mouse buttons (left, middle, right) are hardcoded. This means you cannot use any additional buttons your mouse might have; they will default to opening the popup.