### PR TITLE
Make the applet budgie-10.10 (wayland) compatible

### DIFF
--- a/budgie-media-player-applet.plugin.in
+++ b/budgie-media-player-applet.plugin.in
@@ -1,9 +1,9 @@
 [Plugin]
-Loader=python3
+Loader=@PYTHON@
 Module=applet
 Name=Media Player Applet
 Description=Media controller applet for the budgie panel
 Authors=zalesyc
-Copyright=© 2023-2024 zalesyc
+Copyright=© 2023-2025 zalesyc
 Website=https://github.com/zalesyc/budgie-media-player-applet
 Icon=media-playback-start-symbolic

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,24 @@ PLUGINS_INSTALL_DIR = join_paths(get_option('libdir'), 'budgie-desktop', 'plugin
 PIXMAPS_DIR = join_paths(datadir, 'pixmaps')
 HICOLOR_THEME_DIR = join_paths(datadir, 'icons', 'hicolor')
 
+for_wayland = get_option('for-wayland')
+
+if for_wayland == false
+	python_loader = 'python3'
+else
+	python_loader = 'python' 
+endif
+
+configdata= configuration_data()
+configdata.set('PYTHON', python_loader)
+plugininstall = configure_file(
+    input: 'budgie-media-player-applet.plugin.in',
+    output: 'budgie-media-player-applet.plugin',
+    configuration: configdata
+)
 
 install_data(
-    'budgie-media-player-applet.plugin',
+    plugininstall,
     install_dir: PLUGINS_INSTALL_DIR
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('for-wayland', type : 'boolean', value : 'false', description : 'Build only wayland compatible components')

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -12,7 +12,12 @@ from Popover import Popover
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gio", "2.0")
 gi.require_version("GLib", "2.0")
-gi.require_version("Budgie", "1.0")
+gi.require_version('Libxfce4windowing', '0.0')
+from gi.repository import Libxfce4windowing
+if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
+    gi.require_version('Budgie', '2.0')
+else:
+    gi.require_version('Budgie', '1.0')
 from gi.repository import Gtk, Gio, GLib, Budgie
 
 

--- a/src/Popover.py
+++ b/src/Popover.py
@@ -7,7 +7,12 @@ from SingleAppPlayer import SingleAppPlayer
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gio", "2.0")
-gi.require_version("Budgie", "1.0")
+gi.require_version('Libxfce4windowing', '0.0')
+from gi.repository import Libxfce4windowing
+if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
+    gi.require_version('Budgie', '2.0')
+else:
+    gi.require_version('Budgie', '1.0')
 from gi.repository import Gtk, Gio, Budgie
 
 

--- a/src/applet.py
+++ b/src/applet.py
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import gi.repository
-
-gi.require_version("Budgie", "1.0")
+gi.require_version('Libxfce4windowing', '0.0')
+from gi.repository import Libxfce4windowing
+if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
+    gi.require_version('Budgie', '2.0')
+else:
+    gi.require_version('Budgie', '1.0')
 from gi.repository import Budgie, GObject
 from BudgieMediaPlayer import BudgieMediaPlayer
 

--- a/src/testWin.py
+++ b/src/testWin.py
@@ -8,7 +8,12 @@ import gi.repository
 from BudgieMediaPlayer import BudgieMediaPlayer
 
 gi.require_version("Gtk", "3.0")
-gi.require_version("Budgie", "1.0")
+gi.require_version('Libxfce4windowing', '0.0')
+from gi.repository import Libxfce4windowing
+if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
+    gi.require_version('Budgie', '2.0')
+else:
+    gi.require_version('Budgie', '1.0')
 gi.require_version("GLib", "2.0")
 
 from gi.repository import Gtk, GLib, Budgie


### PR DESCRIPTION
Add some tweaks to enable the plugin work under budgie-10.10 i.e. budgie-wayland

Tested with Ubuntu Budgie 25.04

It does though require an additional dependency libxfce4windowing