### PR TITLE
Budgie 10.9.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sudo apt install git meson ninja-build python3-requests python3-gi libxfce4windo
 Fedora:
 
 ```shell
-sudo dnf install git meson ninja-build python3-requests python3-gobject libxfce4windowing
+sudo dnf install git meson ninja-build python3-requests python3-gobject libxfce4windowing libpeas-loader-python
 ```
 
 Arch Linux:

--- a/README.md
+++ b/README.md
@@ -117,18 +117,19 @@ git clone https://github.com/zalesyc/budgie-media-player-applet.git && cd budgie
 
 #### 3. Build the applet
 
-note: _if you use budgie 10.10 (i.e. with wayland) set `-Dfor-wayland=true`_
+> [!IMPORTANT]
+> If you use budgie **10.9.4 or higher** set `-Dbudgie-api-v2=true`
 
 Ubuntu, Debian, Arch Linux
 
 ```shell
-meson setup build --libdir=/usr/lib --prefix=/usr -Dfor-wayland=false
+meson setup build --libdir=/usr/lib --prefix=/usr -Dbudgie-api-v2=false
 ```
 
 Fedora, openSUSE
 
 ```shell
-meson setup build --libdir=/usr/lib64 --prefix=/usr -Dfor-wayland=false
+meson setup build --libdir=/usr/lib64 --prefix=/usr -Dbudgie-api-v2=false
 ```
 
 #### 4. Install the applet

--- a/meson.build
+++ b/meson.build
@@ -6,20 +6,12 @@ PLUGINS_INSTALL_DIR = join_paths(get_option('libdir'), 'budgie-desktop', 'plugin
 PIXMAPS_DIR = join_paths(datadir, 'pixmaps')
 HICOLOR_THEME_DIR = join_paths(datadir, 'icons', 'hicolor')
 
-for_wayland = get_option('for-wayland')
+budgie_2 = get_option('for-wayland') or get_option('budgie-api-v2')
 
-if for_wayland == false
-	python_loader = 'python3'
-else
-	python_loader = 'python' 
-endif
-
-configdata = configuration_data()
-configdata.set('PYTHON', python_loader)
 plugininstall = configure_file(
     input: 'budgie-media-player-applet.plugin.in',
     output: 'budgie-media-player-applet.plugin',
-    configuration: configdata
+    configuration: {'PYTHON': budgie_2 ? 'python' : 'python3' }
 )
 
 install_data(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('for-wayland', type : 'boolean', value : false, description : 'Build only wayland compatible components')
+option('budgie-api-v2', type : 'boolean', value : false, description : 'Use the budgie-2.0 and budgie-3.0 python apis, required for budgie > 10.9.4')

--- a/src/BudgieApiVersions.py
+++ b/src/BudgieApiVersions.py
@@ -1,0 +1,12 @@
+# Copyright 2025, zalesyc and the budgie-media-player-applet contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Only purpouse of this file is to be used together with testWin.py in testing the
+installed applet uses BudgieLibraryVersion.py.in which is connfigured by meson instead
+"""
+
+BUDGIE_VERSION_X11 = (
+    "2.0"  # set this to "2.0" if budgie > 10.9.4, othervise set this to "1.0"
+)
+BUDGIE_VERSION_WAYLAND = "3.0"

--- a/src/BudgieApiVersions.py.in
+++ b/src/BudgieApiVersions.py.in
@@ -1,0 +1,5 @@
+# Copyright 2025, zalesyc and the budgie-media-player-applet contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+BUDGIE_VERSION_X11="@X11@"
+BUDGIE_VERSION_WAYLAND="3.0"

--- a/src/BudgieMediaPlayer.py
+++ b/src/BudgieMediaPlayer.py
@@ -8,16 +8,18 @@ from PopupPlasmaControlView import PopupPlasmaControlView
 from EnumsStructs import PanelLengthMode
 from FixedSizeBin import FixedSizeBin
 from Popover import Popover
+from BudgieApiVersions import BUDGIE_VERSION_X11, BUDGIE_VERSION_WAYLAND
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gio", "2.0")
 gi.require_version("GLib", "2.0")
-gi.require_version('Libxfce4windowing', '0.0')
+gi.require_version("Libxfce4windowing", "0.0")
 from gi.repository import Libxfce4windowing
+
 if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
-    gi.require_version('Budgie', '2.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_WAYLAND)
 else:
-    gi.require_version('Budgie', '1.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_X11)
 from gi.repository import Gtk, Gio, GLib, Budgie
 
 

--- a/src/Popover.py
+++ b/src/Popover.py
@@ -4,15 +4,17 @@
 import gi
 from typing import Optional
 from SingleAppPlayer import SingleAppPlayer
+from BudgieApiVersions import BUDGIE_VERSION_X11, BUDGIE_VERSION_WAYLAND
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gio", "2.0")
-gi.require_version('Libxfce4windowing', '0.0')
+gi.require_version("Libxfce4windowing", "0.0")
 from gi.repository import Libxfce4windowing
+
 if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
-    gi.require_version('Budgie', '2.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_WAYLAND)
 else:
-    gi.require_version('Budgie', '1.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_X11)
 from gi.repository import Gtk, Gio, Budgie
 
 

--- a/src/applet.py
+++ b/src/applet.py
@@ -1,7 +1,7 @@
 # Copyright 2023 - 2025, zalesyc and the budgie-media-player-applet contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from BudgieLibraryVersion import BUDGIE_VERSION_X11, BUDGIE_VERSION_WAYLAND
+from BudgieApiVersions import BUDGIE_VERSION_X11, BUDGIE_VERSION_WAYLAND
 import gi.repository
 
 gi.require_version("Libxfce4windowing", "0.0")

--- a/src/applet.py
+++ b/src/applet.py
@@ -1,13 +1,16 @@
 # Copyright 2023 - 2025, zalesyc and the budgie-media-player-applet contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from BudgieLibraryVersion import BUDGIE_VERSION_X11, BUDGIE_VERSION_WAYLAND
 import gi.repository
-gi.require_version('Libxfce4windowing', '0.0')
+
+gi.require_version("Libxfce4windowing", "0.0")
 from gi.repository import Libxfce4windowing
+
 if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
-    gi.require_version('Budgie', '2.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_WAYLAND)
 else:
-    gi.require_version('Budgie', '1.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_X11)
 from gi.repository import Budgie, GObject
 from BudgieMediaPlayer import BudgieMediaPlayer
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,9 @@
+budgie_library_version = configure_file(
+    input: 'BudgieApiVersions.py.in',
+    output: 'BudgieApiVersions.py',
+    configuration: {'X11': budgie_2 ? '2.0' : '1.0'}
+)
+
 install_data(
     'applet.py',
     'SingleAppPlayer.py',
@@ -10,5 +16,6 @@ install_data(
     'Labels.py',
     'FixedSizeBin.py',
     'Popover.py',
+    budgie_library_version,
     install_dir: PLUGINS_INSTALL_DIR
 )

--- a/src/testWin.py
+++ b/src/testWin.py
@@ -6,14 +6,16 @@
 import sys
 import gi.repository
 from BudgieMediaPlayer import BudgieMediaPlayer
+from BudgieApiVersions import BUDGIE_VERSION_X11, BUDGIE_VERSION_WAYLAND
 
 gi.require_version("Gtk", "3.0")
-gi.require_version('Libxfce4windowing', '0.0')
+gi.require_version("Libxfce4windowing", "0.0")
 from gi.repository import Libxfce4windowing
+
 if Libxfce4windowing.windowing_get() == Libxfce4windowing.Windowing.WAYLAND:
-    gi.require_version('Budgie', '2.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_WAYLAND)
 else:
-    gi.require_version('Budgie', '1.0')
+    gi.require_version("Budgie", BUDGIE_VERSION_X11)
 gi.require_version("GLib", "2.0")
 
 from gi.repository import Gtk, GLib, Budgie


### PR DESCRIPTION
**Introduce support for budgie 10.9.4**

Budgie 10.9.4 has changed the required budgie python API version.

The required versions are:
- Budgie 10.9.3 and less uses `budgie-1.0`
- Budgie 10.9.4 uses `budgie-2.0`
- Budgie 10.10 uses `budgie-3.0`

There are no required logic changes in the new budgie-2.0 and 3.0 APIs, the only required change is to set the correct required api version. This is achieved by configuring the python file trough meson.

Changes: 
- New `BudgieApiVersions.py` and `BudgieApiVersions.py.in` files containing the required budgie API versions (one version for x11 and one for Wayland)
  - `BudgieApiVersions.py.in` is configured via meson and then installed
  - `BudgieApiVersions.py` is there only to keep `testWin.py` (used for debugging) working and is not installed
- New meson option `budgie-api-v2`, which is an alias to  `for-wayland`, default value for both is `false`
- Use the `budgie-3.0` API under wayland (budgie 10.10), to align with upstream changes

By default this applet targets 10.9.3, if you want to use this on budgie 10.9.4 or 10.10, set the meson option `budgie-api-v2` to true.
